### PR TITLE
Add R Markdown wrapper for scripts

### DIFF
--- a/Code/results/scripts_run.html
+++ b/Code/results/scripts_run.html
@@ -1,0 +1,6 @@
+<html>
+<head><title>scripts_run</title></head>
+<body>
+<p>Failed to execute R scripts: Rscript not found.</p>
+</body>
+</html>

--- a/Code/scripts_run.Rmd
+++ b/Code/scripts_run.Rmd
@@ -1,0 +1,29 @@
+---
+title: "Script Run"
+output: html_document
+---
+
+# Setup
+
+```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
+source("00_setup.R")
+```
+
+# Transport Utilities
+
+```{r transport-utils, echo=FALSE, message=FALSE, warning=FALSE}
+source("01_transport_utils.R")
+```
+
+# Generate Data
+
+```{r generate-data, echo=FALSE, message=FALSE, warning=FALSE}
+source("02_generate_data.R")
+```
+
+# Parametric Baseline
+
+```{r param-baseline, echo=FALSE, message=FALSE, warning=FALSE}
+source("03_param_baseline.R")
+```
+


### PR DESCRIPTION
## Summary
- add `scripts_run.Rmd` to run existing scripts
- include placeholder HTML in results explaining failure due to missing Rscript

## Testing
- `Rscript -e "rmarkdown::render('Code/scripts_run.Rmd', output_file='scripts_run.html', output_dir='Code/results')"` *(fails: Rscript not found)*