### PR TITLE
Add script to skip R execution if Rscript missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,13 @@ Rscript -e "install.packages(c('trtf', 'tram', 'ggplot2', 'extraDistr'), repos='
 
 These commands install R along with `trtf`, `tram`, `ggplot2` and `extraDistr`, which are needed for all examples.
 
+To run the analysis, use the wrapper script
+
+```
+./run_all.sh
+```
+
+This script automatically skips the R-based steps when no `Rscript` binary is available.
+
+
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Wrapper to execute the R workflow if R is available.
+
+set -e
+
+if ! command -v Rscript > /dev/null 2>&1; then
+    echo "R not available; skipping R-based scripts." >&2
+    exit 0
+fi
+
+Rscript Code/run_all.R "$@"


### PR DESCRIPTION
## Summary
- add `run_all.sh` wrapper that checks for Rscript before running the R workflow
- document the wrapper script usage in README

## Testing
- `sh -n run_all.sh`
- `./run_all.sh` (prints message about missing R)
