### PR TITLE
Add environment setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,15 @@ Rscript -e "install.packages(c('trtf', 'tram', 'ggplot2', 'extraDistr'), repos='
 ```
 
 These commands install R along with `trtf`, `tram`, `ggplot2` and `extraDistr`, which are needed for all examples.
+Alternatively, run `./setup_env.sh` to install R and these packages automatically.
+
+To run the analysis, use the wrapper script
+
+```
+./run_all.sh
+```
+
+This script automatically skips the R-based steps when no `Rscript` binary is available.
+
 
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Wrapper to execute the R workflow if R is available.
+
+set -e
+
+if ! command -v Rscript > /dev/null 2>&1; then
+    echo "R not available; skipping R-based scripts." >&2
+    exit 0
+fi
+
+Rscript Code/run_all.R "$@"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+REQUIRED_PACKAGES=(trtf tram ggplot2 extraDistr)
+
+# Install R if missing
+if ! command -v R >/dev/null 2>&1; then
+  echo "R not found. Installing base R..." >&2
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends gnupg ca-certificates software-properties-common
+  sudo apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 'E298A3A825C0D65DFD57CBB651716619E084DAB9'
+  sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+  sudo apt-get update
+  sudo apt-get install -y r-base
+fi
+
+# Install required R packages
+missing_pkgs=$(Rscript -e 'args <- commandArgs(TRUE); req <- args; miss <- req[!(req %in% rownames(installed.packages()))]; cat(paste(miss, collapse=" "))' "${REQUIRED_PACKAGES[@]}")
+if [ -n "$missing_pkgs" ]; then
+  echo "Installing R packages: $missing_pkgs" >&2
+  Rscript -e "install.packages(strsplit('$missing_pkgs', ' ')[[1]], repos='https://cloud.r-project.org')"
+fi
+
+echo "R environment setup complete."


### PR DESCRIPTION
## Summary
- add `setup_env.sh` which installs R and required packages
- document the new script in `README.md`

## Testing
- `bash -n setup_env.sh`
- `bash -n run_all.sh`
- `./run_all.sh` *(fails: R not available)*
- `./setup_env.sh` *(fails: apt-get could not resolve hosts)*