### PR TITLE
Add Dockerfile for R env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/sourcegraph/universal:latest
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        r-base r-base-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN R -q -e "install.packages(c('extraDistr','tram','trtf','ggplot2'), repos='https://cloud.r-project.org')"

--- a/README.md
+++ b/README.md
@@ -130,3 +130,14 @@ therefore automatically ensured.
 
 The repository no longer stores the large PDF artifacts. Download the preprint
 from the arXiv link above if needed.
+
+## Docker image
+
+To build the analysis environment extend the universal base image:
+
+```bash
+docker build -t ghcr.io/yourname/mde-r:latest .
+docker push ghcr.io/yourname/mde-r:latest
+```
+
+Configure Codex by setting `Container-Bild` to `ghcr.io/yourname/mde-r:latest`. The setup script may remain empty.


### PR DESCRIPTION
## Summary
- add Dockerfile extending universal base with R packages
- document container build and registry usage in README

## Testing
- `apt-get update` *(fails: no route to host)*