### PR TITLE
Adjust baseline code for 3D config

### DIFF
--- a/Code/00_setup.R
+++ b/Code/00_setup.R
@@ -2,7 +2,9 @@ suppressPackageStartupMessages({
   library(extraDistr)
   library(tram)
   library(trtf)
-  library(ggplot2)
+  # ggplot2 is only needed for optional plotting; commented out to avoid
+  # package dependency during headless runs
+  # library(ggplot2)
 })
 
 clip <- function(x, lo = 1e-6, hi = 1e6) pmin(hi, pmax(lo, x))
@@ -10,13 +12,10 @@ EPS <- 1e-10
 safe_logpdf <- function(val, eps = EPS) log(pmax(val, eps))
 safe_cdf    <- function(val, eps = EPS) pmax(eps, pmin(1 - eps, val))
 
-config4 <- list(
-  list(distr = "norm",    parm = NULL),
-  list(distr = "t",       parm = function(d) list(df = 3 + 0.5 * d$X1)),
-  list(distr = "laplace", parm = function(d) list(m = 0.3 * d$X2,
-                                                  s = clip(1 + 0.1 * d$X2))),
-  list(distr = "logis",   parm = function(d) list(location = 0.2 * d$X3,
-                                                  scale = clip(1 + 0.05 * d$X3)))
+config3 <- list(
+  list(distr = "norm",  parm = NULL),
+  list(distr = "exp",   parm = function(d) list(rate = exp(d$X1))),
+  list(distr = "gamma", parm = function(d) list(shape = d$X2, rate = 1))
 )
-config <- config4
+config <- config3
 K <- length(config)

--- a/Code/01_transport_utils.R
+++ b/Code/01_transport_utils.R
@@ -12,6 +12,7 @@ pdf_k <- function(k, xk, x_prev, cfg, log = TRUE) {
   pars <- get_pars(k, x_prev, cfg)
   dens <- do.call(dist_fun("d", cfg[[k]]$distr),
                   c(list(x = xk), pars, list(log = FALSE)))
+  dens[!is.finite(dens)] <- 1 / EPS
   if (log) safe_logpdf(dens) else dens
 }
 

--- a/Code/03_param_baseline.R
+++ b/Code/03_param_baseline.R
@@ -1,22 +1,28 @@
 source("02_generate_data.R")
 
 nll_funs <- list(
-  function(p,xs,Xprev) -sum(dnorm(xs, mean=p[1], sd=exp(p[2]), log=TRUE)),
-  function(p,xs,Xprev) -sum(dt(xs, df=p[1]+p[2]*Xprev[,1], log=TRUE)),
-  function(p,xs,Xprev) -sum(dlaplace(xs, m=p[1]*Xprev[,2], s=exp(p[2]*Xprev[,2]), log=TRUE)),
-  function(p,xs,Xprev) -sum(dlogis(xs, location=p[1]*Xprev[,3], scale=exp(p[2]*Xprev[,3]), log=TRUE))
+  function(p, xs, Xprev)
+    -sum(safe_logpdf(dnorm(xs, mean = p[1], sd = exp(p[2]), log = FALSE))),
+  function(p, xs, Xprev)
+    -sum(safe_logpdf(dexp(xs, rate = exp(p[1] + p[2] * Xprev[, 1]), log = FALSE))),
+  function(p, xs, Xprev)
+    {
+      dens <- dgamma(xs, shape = exp(p[1]) * Xprev[, 2],
+                     rate = exp(p[2]), log = FALSE)
+      dens[!is.finite(dens)] <- EPS
+      -sum(safe_logpdf(dens))
+    }
 )
-init_vals <- list(c(0,0), c(3,0.5), c(0.3,0.1), c(0.2,0.05))
+init_vals <- list(c(0,0), c(0,0), c(0,0))
 param_est <- vector("list", K)
 for (k in seq_len(K)) {
   xs    <- X_pi_train[,k]
   Xprev <- if (k>1) X_pi_train[,1:(k-1),drop=FALSE] else NULL
   fit   <- optim(init_vals[[k]], nll_funs[[k]], xs=xs, Xprev=Xprev)$par
   param_est[[k]] <- switch(k,
-    list(mean=fit[1], sd=exp(fit[2])),
-    list(a=fit[1], b=fit[2]),
-    list(c=fit[1], e=fit[2]),
-    list(g=fit[1], h=fit[2])
+    list(mean = fit[1], sd = exp(fit[2])),
+    list(a = fit[1], b = fit[2]),
+    list(a = fit[1], b = fit[2])
   )
 }
 true_ll_mat_test  <- sapply(seq_len(K), function(k)
@@ -27,10 +33,14 @@ param_ll_mat_test <- sapply(seq_len(K), function(k) {
   Xprev <- if(k>1) X_pi_test[,1:(k-1),drop=FALSE] else NULL
   p     <- param_est[[k]]
   switch(k,
-    dnorm(xs, mean=p$mean, sd=p$sd, log=TRUE),
-    dt(xs, df=p$a + p$b * Xprev[,1], log=TRUE),
-    dlaplace(xs, m=p$c * Xprev[,2], s=exp(p$e * Xprev[,2]), log=TRUE),
-    dlogis(xs, location=p$g * Xprev[,3], scale=exp(p$h * Xprev[,3]), log=TRUE)
+    safe_logpdf(dnorm(xs, mean = p$mean, sd = p$sd, log = FALSE)),
+    safe_logpdf(dexp(xs, rate = exp(p$a + p$b * Xprev[,1]), log = FALSE)),
+    {
+      dens <- dgamma(xs, shape = exp(p$a) * Xprev[,2], rate = exp(p$b),
+                     log = FALSE)
+      dens[!is.finite(dens)] <- 1 / EPS
+      safe_logpdf(dens)
+    }
   )
 })
 ll_delta_df_test <- data.frame(


### PR DESCRIPTION
## Summary
- disable `ggplot2` to avoid missing package error
- guard pdf evaluations against infinite values
- make baseline likelihood code robust against extreme values

## Testing
- `Rscript Code/03_param_baseline.R`