### PR TITLE
Fix TRTF logdensity evaluation

### DIFF
--- a/Code/05_joint_evaluation.R
+++ b/Code/05_joint_evaluation.R
@@ -1,9 +1,8 @@
 source("03_param_baseline.R")
 source("04_forest_models.R")
 
-ell_forest <- -0.5 * rowSums(Z_eta_test^2) -
-  (ncol(Z_eta_test)/2) * log(2*pi) + rowSums(LD_hat)
-all.equal(sum(ell_forest), sum(ll_test), tol = 1e-1)
+loglik_forest <- loglik(Z_eta_test, rowSums(LD_hat))
+all.equal(sum(loglik_forest), sum(ll_test), tol = 1e-1)
 
 pdf("results/BlockE_scatterplots.pdf")
 par(mfrow = c(2,2))
@@ -19,7 +18,7 @@ dev.off()
 delta_df <- data.frame(
   dim        = seq_len(ncol(LD_hat)),
   ell_true   = colSums(true_ll_mat_test),
-  ell_forest = colSums(LD_hat)
+  loglik_forest = colSums(LD_hat)
 )
-delta_df$delta <- delta_df$ell_true - delta_df$ell_forest
+delta_df$delta <- delta_df$ell_true - delta_df$loglik_forest
 print(delta_df)


### PR DESCRIPTION
## Summary
- set a deterministic seed before fitting forests
- enforce correct log-density extraction in `predict.mytrtf`
- compute joint log-likelihood with `loglik()`
- update variable names in joint evaluation

## Testing
- `Rscript tests/basic_tests.R`
- `bash lint.sh`