### PR TITLE
Add parameter safety clipping

### DIFF
--- a/Code/01_transport_utils.R
+++ b/Code/01_transport_utils.R
@@ -1,5 +1,19 @@
 source("00_setup.R")
 
+safe_pars <- function(pars, dname) {
+  lo <- EPS
+  hi <- 1e6
+  if (dname == "norm" && !is.null(pars$sd))
+    pars$sd <- clip(pars$sd, lo, hi)
+  if (dname == "exp" && !is.null(pars$rate))
+    pars$rate <- clip(pars$rate, lo, hi)
+  if (dname == "gamma") {
+    if (!is.null(pars$shape)) pars$shape <- clip(pars$shape, lo, hi)
+    if (!is.null(pars$rate))  pars$rate  <- clip(pars$rate, lo, hi)
+  }
+  pars
+}
+
 dist_fun <- function(pref, name) get(paste0(pref, name))
 get_pars <- function(k, x_prev, cfg) {
   ck <- cfg[[k]]
@@ -11,7 +25,8 @@ get_pars <- function(k, x_prev, cfg) {
     colnames(x_prev) <- paste0("X", seq_len(ncol(x_prev)))
     x_df <- as.data.frame(x_prev)
   }
-  ck$parm(x_df)
+  pars <- ck$parm(x_df)
+  safe_pars(pars, ck$distr)
 }
 
 pdf_k <- function(k, xk, x_prev, cfg, log = TRUE) {

--- a/Code/03_param_baseline.R
+++ b/Code/03_param_baseline.R
@@ -7,8 +7,9 @@ nll_funs <- list(
   function(p, xs, Xprev)
     -sum(dexp(xs, rate = exp(p[1] + p[2] * Xprev[, 1]), log = TRUE)),
   function(p, xs, Xprev)
-    -sum(dgamma(xs, shape = exp(p[1]) * Xprev[, 2],
-                rate = exp(p[2]), log = TRUE))
+    -sum(dgamma(xs,
+                shape = clip(exp(p[1]) * Xprev[, 2], EPS, 1e6),
+                rate  = exp(p[2]), log = TRUE))
 
 )
 init_vals <- list(c(0,0), c(0,0), c(0,0))
@@ -35,8 +36,9 @@ param_ll_mat_test <- sapply(seq_len(K), function(k) {
   switch(k,
     dnorm(xs, mean = p$mean, sd = p$sd, log = TRUE),
     dexp(xs, rate = exp(p$a + p$b * Xprev[, 1]), log = TRUE),
-    dgamma(xs, shape = exp(p$a) * Xprev[, 2],
-           rate = exp(p$b), log = TRUE)
+    dgamma(xs,
+           shape = clip(exp(p$a) * Xprev[, 2], EPS, 1e6),
+           rate  = exp(p$b), log = TRUE)
 
 
   )

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -3,6 +3,6 @@
 # Run basic tests and lint. Exit with non-zero if anything fails.
 
 Rscript tests/basic_tests.R || exit 1
-./lint.sh || exit 1
+sh lint.sh || exit 1
 
 echo "Checks completed successfully."


### PR DESCRIPTION
## Summary
- clip parameters for normal, exponential and gamma distributions to avoid invalid values
- ensure run_checks works without executable lint script
- safeguard optimization code with clipping

## Testing
- `sh run_checks.sh`
- `Rscript Code/03_param_baseline.R`