### PR TITLE
Fix paths after moving scripts to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Code/results/
+results/
 output.txt
 output_counts.txt
 checks.log

--- a/basic_tests.R
+++ b/basic_tests.R
@@ -1,7 +1,3 @@
-old_wd <- getwd()
-setwd("Code")
-on.exit(setwd(old_wd))
-
 source("00_setup.R")
 source("01_transport_utils.R")
 

--- a/lint.sh
+++ b/lint.sh
@@ -2,9 +2,9 @@
 # Simple lint: check for trailing whitespace in R files
 
 fail=0
-for f in Code/*.R tests/*.R; do
+for f in *.R; do
   case "$f" in
-    Code/demo* ) continue ;;
+    demo* ) continue ;;
   esac
   if grep -nE "[[:space:]]$" "$f" >/dev/null; then
     echo "Trailing whitespace found in $f" >&2

--- a/roadmap.md
+++ b/roadmap.md
@@ -44,7 +44,7 @@
   ◦ Heatmap empirische Copula der Residuen
 
 • **Dateistruktur**
-  ◦ `run_all.R` ruft `Code/00_setup.R` bis `Code/05_joint_evaluation.R` auf
+  ◦ `run_all.R` ruft `00_setup.R` bis `05_joint_evaluation.R` auf
   ◦ Output-Verzeichnis `results/` für CSV und PDF-Plots
 
 • **To-Do-Checkliste**

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -2,7 +2,7 @@
 
 # Run basic tests and lint. Exit with non-zero if anything fails.
 
-Rscript tests/basic_tests.R || exit 1
+Rscript basic_tests.R || exit 1
 bash lint.sh || exit 1
 
 echo "Checks completed successfully."


### PR DESCRIPTION
## Summary
- update lint and test scripts to work with scripts located in repository root
- fix `basic_tests.R` and roadmap after folder restructure
- ignore results directory in `.gitignore`

## Testing
- `bash run_checks.sh`