### PR TITLE
Improve kernel smoothing stability

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -31,6 +31,12 @@ safe_logdens <- function(val, eps = EPS, hi = 1e6) {
   res
 }
 
+## log-sum-exp for stable aggregation
+logsumexp <- function(x) {
+  m <- max(x)
+  m + log(sum(exp(x - m)))
+}
+
 ## Bound a CDF away from 0 and 1
 safe_cdf <- function(val, eps = EPS) {
   res <- pmax(eps, pmin(1 - eps, val))


### PR DESCRIPTION
## Summary
- stabilize kernel density weights with log-sum-exp aggregation
- expose `logsumexp()` utility

## Testing
- `bash run_checks.sh`
