### PR TITLE
Ensure sequential estimator works for any K

### DIFF
--- a/04_forest_models.R
+++ b/04_forest_models.R
@@ -1,16 +1,24 @@
 
 ## -------------------------------------------------------------------
 ## Overview of this script
-## - Input: training sample `X_pi_train` and test sample `X_pi_test`
-##   generated in `02_generate_data.R`.
+##
+## Goal: Train a transformation forest estimator on observation
+##       vectors \(x^{(i)} \in \mathbb R^K\) and evaluate the
+##       sequential log-density on a separate test sample.  Both
+##       training and testing rely exclusively on the matrices
+##       `X_pi_train` and `X_pi_test` generated in
+##       `02_generate_data.R`.
+##
 ## - Output: transformation forest model `model` and matrix `LD_hat`
 ##   containing log-density contributions for the test data.
 ## - Algorithm:
-##   1. Fit a marginal Box--Cox model for each component of `X_pi_train`.
-##   2. Fit a conditional transformation forest for each response
-##      `X_pi_k` given `X_pi_{<k}`.
-##   3. Predict log-density contributions on `X_pi_test` and assemble
-##      them into `LD_hat`.
+##   1. For each coordinate \(k=1,\dots,K\) fit a marginal Box--Cox model
+##      on the single column `X_pi_train[, k]`.
+##   2. For every \(k>1\) fit a conditional transformation forest for
+##      the response `X_pi_k` given all preceding coordinates
+##      `X_pi_{<k}`.  The fit uses only these columns.
+##   3. Predict log-density contributions on `X_pi_test` sequentially
+##      and assemble them into `LD_hat`.
 ## -------------------------------------------------------------------
 source("02_generate_data.R")
 
@@ -20,24 +28,23 @@ library(trtf)
 set.seed(2046)
 
 fit_forest <- function(data) {
-  ymod <- lapply(names(data), function(y)
-    BoxCox(as.formula(paste0(y, "~1")), data = data)
+  ymod <- lapply(seq_len(ncol(data)), function(j)
+    BoxCox(as.formula(paste0(names(data)[j], "~1")), data = data[, j, drop = FALSE])
   )
-  fm <- lapply(2:ncol(data), function(j)
-    as.formula(paste0(
-      names(data)[j], " ~ ",
-      paste(names(data)[1:(j-1)], collapse = "+")
+  forests <- vector("list", ncol(data) - 1L)
+  for (k in 2:ncol(data)) {
+    fm <- as.formula(paste0(
+      names(data)[k], " ~ ",
+      paste(names(data)[1:(k-1)], collapse = "+")
     ))
-  )
-  forests <- lapply(seq_along(fm), function(j)
-    traforest(
-      ymod[[j + 1L]], formula = fm[[j]], data = data,
+    forests[[k - 1L]] <- traforest(
+      ymod[[k]], formula = fm, data = data[, seq_len(k)],
       ntree = 200,
-      mtry = ceiling((j - 1) / 3),
+      mtry = ceiling((k - 1) / 3),
       minbucket = 20,
       trace = TRUE
     )
-  )
+  }
   structure(list(ymod = ymod, forests = forests), class = "mytrtf")
 }
 
@@ -45,17 +52,22 @@ predict.mytrtf <- function(object, newdata,
                            type = c("logdensity", "distribution",
                                      "density", "trafo", "response")) {
   type <- match.arg(type)
-  ld1 <- predict(object$ymod[[1]], newdata = newdata, type = type)
-  ldf <- lapply(object$forests, function(frst) {
+  K <- length(object$ymod)
+  ld <- matrix(NA_real_, nrow(newdata), K)
+  ## k = 1: marginal model
+  ld[, 1] <- predict(object$ymod[[1]], newdata = newdata[, 1, drop = FALSE],
+                     type = type)
+  for (k in 2:K) {
+    frst <- object$forests[[k - 1L]]
+    nd_sub <- newdata[, seq_len(k), drop = FALSE]
     resp <- variable.names(frst$model)[1]
-    q    <- newdata[[resp]]
-    pr   <- predict(frst, newdata = newdata, q = q,
-                    type = type, simplify = FALSE)
-    diag(do.call(cbind, pr))
-  })
-  ld_mat <- cbind(ld1, do.call(cbind, ldf))
-  stopifnot(all(is.finite(ld_mat)))
-  ld_mat
+    q <- nd_sub[[resp]]
+    pr <- predict(frst, newdata = nd_sub, q = q,
+                  type = type, simplify = FALSE)
+    ld[, k] <- diag(do.call(cbind, pr))
+  }
+  stopifnot(all(is.finite(ld)))
+  ld
 }
 
 model  <- fit_forest(as.data.frame(X_pi_train))


### PR DESCRIPTION
## Summary
- document transformation forest estimation for general K
- drop dimension-specific guards
- iterate log-density prediction unconditionally over `k=2:K`

## Testing
- `bash run_checks.sh`
