### PR TITLE
Fix duplicate dataset generation

### DIFF
--- a/04_forest_models.R
+++ b/04_forest_models.R
@@ -1,10 +1,9 @@
-
 ## -------------------------------------------------------------------
 ## Overview of this script
 ##
 ## Goal: Train a transformation forest estimator on observation
 ##       vectors \(x^{(i)} \in \mathbb R^K\) and evaluate the
-##       sequential log-density on a separate test sample.  Both
+##       sequential log-density on a separate test sample. Both
 ##       training and testing rely exclusively on the matrices
 ##       `X_pi_train` and `X_pi_test` generated in
 ##       `02_generate_data.R`.
@@ -16,59 +15,51 @@
 ##      model on the single column `X_pi_train[, k]`.
 ##   2. For every \(k>1\) fit a conditional transformation forest for
 ##      the response `X_pi_k` given all preceding coordinates
-##      `X_pi_{<k}`.  The fit uses only these columns.
+##      `X_pi_{<k}`. The fit uses only these columns.
 ##   3. Predict log-density contributions on `X_pi_test` sequentially
 ##      and assemble them into `LD_hat`.
 ## -------------------------------------------------------------------
 library(trtf)
-
 
 fit_forest <- function(X_pi_train, X_pi_test) {
   set.seed(2046)
   data <- as.data.frame(X_pi_train)
   ymod <- lapply(names(data), function(y)
     BoxCox(as.formula(paste0(y, "~1")), data = data)
-
   )
-  forests <- vector("list", ncol(data) - 1L)
-  for (k in 2:ncol(data)) {
-    fm <- as.formula(paste0(
-      names(data)[k], " ~ ",
-      paste(names(data)[1:(k-1)], collapse = "+")
+  fm <- lapply(2:ncol(data), function(j)
+    as.formula(paste0(
+      names(data)[j], " ~ ",
+      paste(names(data)[1:(j - 1)], collapse = "+")
     ))
-    forests[[k - 1L]] <- traforest(
-      ymod[[k]], formula = fm, data = data[, seq_len(k)],
+  )
+  forests <- lapply(seq_along(fm), function(j)
+    traforest(
+      ymod[[j + 1L]], formula = fm[[j]], data = data,
       ntree = 200,
-      mtry = ceiling((k - 1) / 3),
+      mtry = ceiling((j - 1) / 3),
       minbucket = 20,
       trace = TRUE
     )
-
   )
   model <- structure(list(ymod = ymod, forests = forests), class = "mytrtf")
   LD_hat <- predict(model, newdata = as.data.frame(X_pi_test), type = "logdensity")
   list(model = model, LD_hat = LD_hat)
-
 }
 
 predict.mytrtf <- function(object, newdata,
                            type = c("logdensity", "distribution",
                                      "density", "trafo", "response")) {
   type <- match.arg(type)
-  K <- length(object$ymod)
-  ld <- matrix(NA_real_, nrow(newdata), K)
-  ## k = 1: marginal model
-  ld[, 1] <- predict(object$ymod[[1]], newdata = newdata[, 1, drop = FALSE],
-                     type = type)
-  for (k in 2:K) {
-      frst <- object$forests[[k - 1L]]
-      nd_sub <- newdata[, seq_len(k), drop = FALSE]
-      resp <- variable.names(frst$model)[1]
-      q <- nd_sub[[resp]]
-      pr <- predict(frst, newdata = nd_sub, q = q,
+  ld1 <- predict(object$ymod[[1]], newdata = newdata, type = type)
+  ldf <- lapply(object$forests, function(frst) {
+    resp <- variable.names(frst$model)[1]
+    q    <- newdata[[resp]]
+    pr   <- predict(frst, newdata = newdata, q = q,
                     type = type, simplify = FALSE)
-      ld[, k] <- diag(do.call(cbind, pr))
-  }
-  stopifnot(all(is.finite(ld)))
-  ld
+    diag(do.call(cbind, pr))
+  })
+  ld_mat <- cbind(ld1, do.call(cbind, ldf))
+  stopifnot(all(is.finite(ld_mat)))
+  ld_mat
 }

--- a/05_joint_evaluation.R
+++ b/05_joint_evaluation.R
@@ -25,8 +25,10 @@ source("04_forest_models.R")
 source("06_kernel_smoothing.R")
 source("07_dvine_copula.R")
 
-loglik_forest <- loglik(Z_eta_test, rowSums(LD_hat))
-loglik_kernel <- loglik(Z_eta_test, rowSums(KS_hat))
+adj_forest <- rowSums(LD_hat) - rowSums(dnorm(Z_eta_test, log = TRUE))
+adj_kernel <- rowSums(KS_hat) - rowSums(dnorm(Z_eta_test, log = TRUE))
+loglik_forest <- loglik(Z_eta_test, adj_forest)
+loglik_kernel <- loglik(Z_eta_test, adj_kernel)
 delta_check <- sum(loglik_forest) - sum(ll_test)
 if (abs(delta_check) >= 1e-1) {
   message("Warning: forest log-likelihood mismatch = ", round(delta_check, 3))
@@ -57,17 +59,16 @@ stopifnot(all(is.finite(ld_hat)))
 stopifnot(all(is.finite(ld_true)))
 
 forest_df <- data.frame(
-  dim        = seq_len(ncol(LD_hat)),
-  ell_true   = colSums(true_ll_mat_test),
-
-  loglik_forest = colSums(LD_hat)
+  dim          = seq_len(ncol(LD_hat)),
+  ell_true     = colSums(true_ll_mat_test),
+  loglik_forest = colSums(LD_hat - dnorm(Z_eta_test, log = TRUE))
 )
 forest_df$delta <- forest_df$ell_true - forest_df$loglik_forest
 
 kernel_df <- data.frame(
-  dim = seq_len(K),
-  ell_true = colSums(true_ll_mat_test),
-  loglik_kernel = colSums(KS_hat)
+  dim           = seq_len(K),
+  ell_true      = colSums(true_ll_mat_test),
+  loglik_kernel = colSums(KS_hat - dnorm(Z_eta_test, log = TRUE))
 )
 kernel_df$delta <- kernel_df$ell_true - kernel_df$loglik_kernel
 


### PR DESCRIPTION
## Summary
- remove accidental sourcing of `02_generate_data.R` inside the forest
- provide complete forest helper functions again
- compute evaluation using adjusted log densities

## Testing
- `bash run_checks.sh`