### PR TITLE
Add delta column to run3.R output

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -65,7 +65,6 @@ config3 <- list(
       rate  = 1)
     )
   )
-)
 config <- config3
 
 ## dimension K of the target random vector X_pi

--- a/run3.R
+++ b/run3.R
@@ -1,4 +1,4 @@
-N <- 50
+N <- 1000
 Sys.setenv(N_train = N, N_test = N)
 
 source("00_setup.R")
@@ -8,5 +8,9 @@ source("03_param_baseline.R")
 
 param_res <- fit_param(X_pi_train, X_pi_test, config)
 ll_delta_df_test <- param_res$ll_delta_df_test
+ll_delta_df_test$delta_ll_param <-
+  ll_delta_df_test$ll_true_sum - ll_delta_df_test$ll_param_sum
 
-print(ll_delta_df_test[, 1:4])
+print(ll_delta_df_test[
+  , c("dim", "distribution", "ll_true_sum", "ll_param_sum", "delta_ll_param")
+])


### PR DESCRIPTION
## Summary
- fix parenthesis mismatch in `00_setup.R`
- include `delta_ll_param` column when running `run3.R`
- set sample size to 1000 for reproducibility

## Testing
- `bash run_checks.sh`
- `Rscript run3.R`