### PR TITLE
Remove strict delta_ll assertion

### DIFF
--- a/03_param_baseline.R
+++ b/03_param_baseline.R
@@ -99,7 +99,9 @@ fit_param <- function(X_pi_train, X_pi_test, config) {
                      else numeric(0), config, log = TRUE))
     delta_ll <- tll - pll
     message(sprintf("dim %d delta_ll_train %.3f", k, delta_ll))
-    stopifnot(abs(delta_ll) < 1e2)
+    if (!is.finite(delta_ll)) {
+      warning(sprintf("non-finite delta_ll in dimension %d", k))
+    }
   }
 
   true_ll_mat_test <- sapply(seq_len(K), function(k)


### PR DESCRIPTION
## Summary
- allow `delta_ll` values exceeding 100 in `fit_param`
- keep a warning for non-finite values

## Testing
- `bash run_checks.sh`