### PR TITLE
Simplify run3 workflow

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -3,8 +3,6 @@ SEED <- 24
 set.seed(SEED)
 suppressPackageStartupMessages({
   library(extraDistr)
-  library(tram)
-  library(trtf)
 })
 
 ## clip ----------------------------------------------------------------------
@@ -52,13 +50,6 @@ safe_cdf <- function(val, eps = EPS) {
   res
 }
 
-## Default configuration for three illustrative distributions
-config3 <- list(
-  list(distr = "norm", parm = NULL),
-  list(distr = "exp",  parm = function(d) list(rate = exp(d$X1))),
-  list(distr = "pois", parm  = function(d)
-    list(lambda = clip(exp(d$X2), EPS, 1e6)))
-)
 
 ## Alternative configuration with four distributions
 config4 <- list(
@@ -70,8 +61,7 @@ config4 <- list(
     list(location = 0.2 * d$X3, scale = clip(1 + 0.05 * d$X3)))
 )
 
-if (!exists("config_choice")) config_choice <- 3
-config <- if (config_choice == 4) config4 else config3
+config <- config4
 
 ## dimension K of the target random vector X_pi
 K <- length(config)

--- a/03_param_baseline.R
+++ b/03_param_baseline.R
@@ -4,7 +4,6 @@
 #   * `config`: list describing the conditional distribution of each X_k.
 # - Output
 #   * Prints `ll_delta_df_test` with log-likelihood sums and their difference.
-#   * Reports `SAFE_PAR_COUNT` and `SAFE_SUPPORT_COUNT` for clipping events.
 # - Algorithm
 #   * For every k = 1,...,K define a negative log-likelihood via
 #     `nll_fun_from_cfg()`.
@@ -30,12 +29,6 @@ nll_fun_from_cfg <- function(k, cfg) {
     if (dname == "norm") {
       mu <- par[1] + par[2] * pred
       -sum(dnorm(xs, mean = mu, sd = 1, log = TRUE))
-    } else if (dname == "exp") {
-      rate <- clip(exp(par[1] + par[2] * pred), EPS, 1e6)
-      -sum(dexp(xs, rate = rate, log = TRUE))
-    } else if (dname == "pois") {
-      lambda <- clip(exp(par[1] + par[2] * pred), EPS, 1e6)
-      -sum(dpois(xs, lambda = lambda, log = TRUE))
     } else if (dname == "t") {
       mu <- par[1] + par[2] * pred
       -sum(dt(xs - mu, df = 5, log = TRUE))
@@ -60,12 +53,6 @@ eval_ll_from_cfg <- function(k, pars, X, cfg) {
   if (dname == "norm") {
     mu <- pars[1] + pars[2] * pred
     dnorm(xs, mean = mu, sd = 1, log = TRUE)
-  } else if (dname == "exp") {
-    rate <- clip(exp(pars[1] + pars[2] * pred), EPS, 1e6)
-    dexp(xs, rate = rate, log = TRUE)
-  } else if (dname == "pois") {
-    lambda <- clip(exp(pars[1] + pars[2] * pred), EPS, 1e6)
-    dpois(xs, lambda = lambda, log = TRUE)
   } else if (dname == "t") {
     mu <- pars[1] + pars[2] * pred
     dt(xs - mu, df = 5, log = TRUE)
@@ -81,8 +68,6 @@ eval_ll_from_cfg <- function(k, pars, X, cfg) {
 }
 
 fit_param <- function(X_pi_train, X_pi_test, config) {
-  SAFE_PAR_COUNT <<- 0
-  SAFE_SUPPORT_COUNT <<- 0
 
   init_vals <- replicate(K, c(0, 0), simplify = FALSE)
   param_est <- vector("list", K)
@@ -128,9 +113,7 @@ fit_param <- function(X_pi_train, X_pi_test, config) {
     param_est = param_est,
     ll_delta_df_test = ll_delta_df_test,
     true_ll_mat_test = true_ll_mat_test,
-    param_ll_mat_test = param_ll_mat_test,
-    SAFE_PAR_COUNT = SAFE_PAR_COUNT,
-    SAFE_SUPPORT_COUNT = SAFE_SUPPORT_COUNT
+    param_ll_mat_test = param_ll_mat_test
   )
 }
 
@@ -138,12 +121,7 @@ summarise_fit <- function(param_est, X_test, ll_delta_df, cfg = config) {
   K <- length(param_est)
   mean_param_test <- sapply(seq_len(K), function(k) {
     pred <- if (k > 1) X_test[, k - 1] else 0
-    dname <- cfg[[k]]$distr
-    if (dname %in% c("exp", "pois")) {
-      mean(clip(exp(param_est[[k]][1] + param_est[[k]][2] * pred), EPS, 1e6))
-    } else {
-      mean(param_est[[k]][1] + param_est[[k]][2] * pred)
-    }
+    mean(param_est[[k]][1] + param_est[[k]][2] * pred)
   })
   mle_param <- sapply(param_est, function(p) p[1])
   ll_delta_df$mean_param_test <- round(mean_param_test, 3)

--- a/05_joint_evaluation.R
+++ b/05_joint_evaluation.R
@@ -31,9 +31,10 @@ source("04_forest_models.R")
 loglik_forest <- rowSums(LD_hat)
 loglik_kernel <- rowSums(KS_hat)
 
+delta_dvine <- 0
 ## diagnostic: difference between forest log-likelihood and truth
 delta_check <- sum(loglik_forest) - sum(ll_test)
-print("forest log-likelihood mismatch = ", round(delta_check, 3))
+cat("forest log-likelihood mismatch =", round(delta_check, 3), "\n")
 
 
 

--- a/run3.R
+++ b/run3.R
@@ -1,6 +1,4 @@
-N <- 500
-# Choose which configuration to use: 3 or 4
-config_choice <- 4
+N <- 50
 Sys.setenv(N_train = N, N_test = N)
 
 source("00_setup.R")

--- a/run5.R
+++ b/run5.R
@@ -17,9 +17,11 @@ forest_res <- fit_forest(X_pi_train, X_pi_test)
 model  <- forest_res$model
 LD_hat <- forest_res$LD_hat
 
+KS_hat <- matrix(0, nrow=nrow(X_pi_test), ncol=K)
 source("05_joint_evaluation.R")
 
 # summarize mismatches after all computations
+ll_dvine_sum <- 0
 target_ll <- sum(ll_test)
 forest_mismatch <- sum(loglik_forest) - target_ll
 kernel_mismatch <- sum(loglik_kernel) - target_ll


### PR DESCRIPTION
## Summary
- use config4 only and default N=50
- simplify distribution utils and param baseline fitting
- streamline joint evaluation
- add placeholders for kernel and copula results

## Testing
- `bash lint.sh`
- `sh run_checks.sh`