### PR TITLE
Add kernel smoothing joint evaluation

### DIFF
--- a/05_joint_evaluation.R
+++ b/05_joint_evaluation.R
@@ -17,6 +17,7 @@
 
 source("03_param_baseline.R")
 source("04_forest_models.R")
+## Expect KS_hat from kernel smoothing already computed
 
 
 
@@ -28,10 +29,13 @@ source("04_forest_models.R")
 ## original data.  Hence the joint log-likelihood is simply the row sum
 ## without any normalising Gaussian terms.
 loglik_trtf <- rowSums(LD_hat)
+loglik_kernel <- rowSums(KS_hat)
 
 ## diagnostic: difference between forest log-likelihood and truth
 delta_check <- sum(loglik_trtf) - sum(ll_test)
 message(sprintf("trtf log-likelihood mismatch = %.3f", delta_check))
+delta_check_ks <- sum(loglik_kernel) - sum(ll_test)
+message(sprintf("kernel log-likelihood mismatch = %.3f", delta_check_ks))
 
 
 
@@ -39,8 +43,10 @@ message(sprintf("trtf log-likelihood mismatch = %.3f", delta_check))
 ## plot true vs estimated joint log-densities
 ld_hat  <- rowSums(LD_hat)
 ld_true <- rowSums(true_ll_mat_test)
+ld_hat_ks <- rowSums(KS_hat)
 stopifnot(all(is.finite(ld_hat)))
 stopifnot(all(is.finite(ld_true)))
+stopifnot(all(is.finite(ld_hat_ks)))
 
 forest_df <- data.frame(
   dim           = seq_len(ncol(LD_hat)),
@@ -48,6 +54,13 @@ forest_df <- data.frame(
   loglik_trtf = colSums(LD_hat)
 )
 forest_df$delta <- forest_df$ell_true - forest_df$loglik_trtf
+
+kernel_df <- data.frame(
+  dim           = seq_len(ncol(KS_hat)),
+  ell_true      = colSums(true_ll_mat_test),
+  loglik_kernel = colSums(KS_hat)
+)
+kernel_df$delta <- kernel_df$ell_true - kernel_df$loglik_kernel
 
 
 # merge results
@@ -57,9 +70,11 @@ eval_df <- data.frame(
   ll_true_sum = ll_delta_df_test$ll_true_sum,
   ll_param_sum = ll_delta_df_test$ll_param_sum,
   ll_trtf_sum = forest_df$loglik_trtf,
+  ll_kernel_sum = kernel_df$loglik_kernel,
   delta_ll_param = if ("delta_ll_param" %in% names(ll_delta_df_test))
     ll_delta_df_test$delta_ll_param else ll_delta_df_test$delta_ll,
-  delta_ll_trtf = forest_df$delta
+  delta_ll_trtf = forest_df$delta,
+  delta_ll_kernel = kernel_df$delta
 )
 write.csv(eval_df, "results/evaluation_summary.csv", row.names = FALSE)
 
@@ -67,8 +82,11 @@ png("results/joint_logdensity_scatterplot.png")
 plot(ld_hat, ld_true, xlab = "estimated", ylab = "true")
 abline(a = 0, b = 1)
 info_text <- sprintf(
-  "N = %d | sum(delta_ll_param) = %.3f | sum(delta_ll_trtf) = %.3f",
-  N_test, sum(eval_df$delta_ll_param), sum(eval_df$delta_ll_trtf)
+  "N = %d | sum(delta_ll_param) = %.3f | sum(delta_ll_trtf) = %.3f | sum(delta_ll_kernel) = %.3f",
+  N_test,
+  sum(eval_df$delta_ll_param),
+  sum(eval_df$delta_ll_trtf),
+  sum(eval_df$delta_ll_kernel)
 )
 mtext(info_text, side = 1, line = 3)
 dev.off()

--- a/run5.R
+++ b/run5.R
@@ -23,13 +23,17 @@ forest_res <- fit_forest(X_pi_train, X_pi_test)
 model  <- forest_res$model
 LD_hat <- forest_res$LD_hat
 
+source("06_kernel_smoothing.R")
+
 source("05_joint_evaluation.R")
 
 # summarize mismatches after all computations
 target_ll <- sum(ll_test)
 forest_mismatch <- sum(loglik_trtf) - target_ll
+kernel_mismatch <- sum(loglik_kernel) - target_ll
 
 cat("trtf logL mismatch =", round(forest_mismatch, 3), "\n")
+cat("kernel logL mismatch =", round(kernel_mismatch, 3), "\n")
 
 eval_tab <- read.csv("results/evaluation_summary.csv")
 print(eval_tab)
@@ -42,3 +46,11 @@ plot(ld_hat, ld_true,
 abline(a = 0, b = 1)
 dev.off()
 message("Saved plot to results/run5_logdensity_scatterplot.png")
+
+png("results/run5_kernel_logdensity_scatterplot.png")
+plot(ld_hat_ks, ld_true,
+     xlab = "estimated log-density",
+     ylab = "true log-density")
+abline(a = 0, b = 1)
+dev.off()
+message("Saved plot to results/run5_kernel_logdensity_scatterplot.png")

--- a/tests/testthat/test_mismatch.R
+++ b/tests/testthat/test_mismatch.R
@@ -9,6 +9,8 @@ if (file.exists('../../run5.R')) {
 
 test_that('joint mismatches are finite', {
   expect_true(is.finite(forest_mismatch))
+  expect_true(is.finite(kernel_mismatch))
   expect_true(all(is.finite(eval_tab$delta_ll_param)))
   expect_true(all(is.finite(eval_tab$delta_ll_trtf)))
+  expect_true(all(is.finite(eval_tab$delta_ll_kernel)))
 })


### PR DESCRIPTION
## Summary
- support kernel smoothing in joint evaluation
- update run5.R to source kernel smoother and produce extra plot
- extend mismatch test to cover kernel smoothing

## Testing
- `bash run_checks.sh`