### PR TITLE
Fix logdet naming and likelihood sums

### DIFF
--- a/01_transport_utils.R
+++ b/01_transport_utils.R
@@ -180,9 +180,9 @@ qtf_k <- function(k, u, x_prev, cfg, log.p = FALSE) {
   safe_support(res, dname, pars)
 }
 
-det_J <- function(logd) rowSums(logd)
-loglik <- function(Z_eta, logdet) {
-  -0.5 * rowSums(Z_eta^2) - (ncol(Z_eta)/2) * log(2 * pi) + logdet
+logdet_J <- function(logd) rowSums(logd)
+loglik <- function(Z_eta, logdet_J) {
+  -0.5 * rowSums(Z_eta^2) - (ncol(Z_eta)/2) * log(2 * pi) + logdet_J
 }
 eta_sample <- function(N) {
   Z_eta <- matrix(rnorm(N * K), nrow = N)

--- a/02_generate_data.R
+++ b/02_generate_data.R
@@ -9,15 +9,16 @@
 #
 # Outputs:
 # - `results/train_data.csv` containing columns `Xpi*`, `Ueta*`, `Zeta*`,
-#   `logd*`, `det_J` and `ll_true` for each observation.
+#   `logd*`, `det_J` and `ll_true` for each observation (where `det_J`
+#   stores the log-determinant).
 # - `results/test_data.csv` with the same column names.
 #
 # Algorithmic steps:
 # 1. Draw `U_eta` from the reference distribution `eta`.
 # 2. Apply the inverse map `S_inv(U_eta)` sequentially to obtain `X_pi`,
 #    `Z_eta`, and the log partial derivatives `logd`.
-# 3. Compute `det(J) = rowSums(logd)` and evaluate the log-likelihood via
-#    `loglik(Z_eta, det(J))`.
+# 3. Compute `logdet_J = rowSums(logd)` and evaluate the log-likelihood via
+#    `loglik(Z_eta, logdet_J)`.
 # 4. Print exploratory summaries for `X_pi` and the range of `det(J)`.
 # 5. Combine the variables into data frames and store them as CSV files.
 #
@@ -33,12 +34,12 @@ U_eta_train <- samp_train$U_eta
 Z_eta_train <- samp_train$Z_eta
 logd_train <- samp_train$logd
 
-det_J_train <- det_J(logd_train)
-ll_train <- loglik(Z_eta_train, det_J_train)
+logdet_J_train <- logdet_J(logd_train)
+ll_train <- loglik(Z_eta_train, logdet_J_train)
 cat("Train EDA:\n")
 cat("- X_pi_train Mean: ", paste(round(colMeans(X_pi_train), 3), collapse = ", "), "\n")
 cat("- X_pi_train SD:   ", paste(round(apply(X_pi_train, 2, sd), 3), collapse = ", "), "\n")
-cat("- log_det(J)_train Range: [", round(min(det_J_train), 3), ",", round(max(det_J_train), 3), "]\n\n")
+cat("- log_det(J)_train Range: [", round(min(logdet_J_train), 3), ",", round(max(logdet_J_train), 3), "]\n\n")
 
 set.seed(2045)
 N_test <- as.integer(Sys.getenv("N_test", "500"))
@@ -48,19 +49,19 @@ U_eta_test <- samp_test$U_eta
 Z_eta_test <- samp_test$Z_eta
 logd_test <- samp_test$logd
 
-det_J_test <- det_J(logd_test)
-ll_test <- loglik(Z_eta_test, det_J_test)
+logdet_J_test <- logdet_J(logd_test)
+ll_test <- loglik(Z_eta_test, logdet_J_test)
 cat("Test EDA:\n")
 cat("- X_pi_test Mean: ", paste(round(colMeans(X_pi_test), 3), collapse = ", "), "\n")
 cat("- X_pi_test SD:   ", paste(round(apply(X_pi_test, 2, sd), 3), collapse = ", "), "\n")
-cat("- log_det(J)_test Range: [", round(min(det_J_test), 3), ",", round(max(det_J_test), 3), "]\n\n")
+cat("- log_det(J)_test Range: [", round(min(logdet_J_test), 3), ",", round(max(logdet_J_test), 3), "]\n\n")
 
 if (!dir.exists("results")) dir.create("results")
 
 # combine training data into one CSV
 train_df <- data.frame(
   X_pi_train, U_eta_train, Z_eta_train, logd_train,
-  det_J = det_J_train, ll_true = ll_train,
+  det_J = logdet_J_train, ll_true = ll_train,
   check.names = FALSE
 )
 colnames(train_df) <- c(
@@ -76,7 +77,7 @@ write.csv(train_df, "results/train_data.csv", row.names = FALSE)
 # combine test data into one CSV
 test_df <- data.frame(
   X_pi_test, U_eta_test, Z_eta_test, logd_test,
-  det_J = det_J_test, ll_true = ll_test,
+  det_J = logdet_J_test, ll_true = ll_test,
   check.names = FALSE
 )
 colnames(test_df) <- colnames(train_df)

--- a/03_param_baseline.R
+++ b/03_param_baseline.R
@@ -114,11 +114,14 @@ fit_param <- function(X_pi_train, X_pi_test, config) {
     eval_ll_from_cfg(k, param_est[[k]], X_pi_test, config)
   )
 
+  ## per-observation joint log-likelihood using row sums (see AGENTS.md)
+  ll_param_sum <- rowSums(param_ll_mat_test)
+
   ll_delta_df_test <- data.frame(
     dim          = seq_len(K),
     distribution = sapply(config, `[[`, "distr"),
     ll_true_sum  = apply(true_ll_mat_test, 2, sum),
-    ll_param_sum = apply(param_ll_mat_test, 2, sum)
+    ll_param_sum = colSums(param_ll_mat_test)
   )
   ll_delta_df_test$delta_ll_param <-
     ll_delta_df_test$ll_true_sum - ll_delta_df_test$ll_param_sum

--- a/roadmap.md
+++ b/roadmap.md
@@ -68,6 +68,6 @@
 
 1. **Notation:** Every variable gets the suffix `_pi` (target domain) or
    `_eta` (reference domain) exactly as in Table 1 of the tutorial.
-2. **Log determinant:** Make sure `det_J(logd)` is added **before** the
+2. **Log determinant:** Make sure `logdet_J(logd)` is added **before** the
    bias term inside the log-likelihood call.
 


### PR DESCRIPTION
## Summary
- compute per-observation log-likelihood with `rowSums`
- rename Jacobian log-determinant helper to `logdet_J`
- adjust data generation and docs to new naming

## Testing
- `sh run_checks.sh`
- `Rscript run5.R`