### PR TITLE
Update baseline to gamma example

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -49,10 +49,13 @@ safe_cdf <- function(val, eps = EPS) {
 
 ## Standard-Config mit drei Verteilungen
 config3 <- list(
+  ## normal with mean 0, sd 1
   list(distr = "norm", parm = NULL),
+  ## exponential rate depends on previous dimension
   list(distr = "exp",  parm = function(d) list(rate = exp(d$X1))),
-  list(distr = "pois", parm  = function(d)
-    list(lambda = clip(exp(d$X2), EPS, 1e6)))
+  ## gamma shape depends on X2, fixed rate 1
+  list(distr = "gamma", parm  = function(d)
+    list(shape = clip(d$X2, EPS, 1e6), rate = 1))
 )
 
 ## Alternative Config mit vier Verteilungen

--- a/03_param_baseline.R
+++ b/03_param_baseline.R
@@ -7,8 +7,8 @@
 #   * Logdichten mit `eval_ll_from_cfg()` auswerten
 #   * Differenzen in `ll_delta_df_test` sammeln
 
-safe_optim <- function(par, fn, ...) {
-  res <- optim(par, fn, hessian = TRUE, ...)
+safe_optim <- function(par, fn, method = "BFGS", ...) {
+  res <- optim(par, fn, hessian = TRUE, method = method, ...)
   if (any(is.na(res$hessian))) stop("NA Hessian in optimisation")
   if (any(!is.finite(res$par)) || !is.finite(res$value))
     stop("Non-finite optimiser result")
@@ -28,6 +28,9 @@ nll_fun_from_cfg <- function(k, cfg) {
     } else if (dname == "exp") {
       rate <- clip(exp(par[1] + par[2] * pred), EPS, 1e6)
       -sum(dexp(xs, rate = rate, log = TRUE))
+    } else if (dname == "gamma") {
+      shape <- clip(par[1] + par[2] * pred, EPS, 1e6)
+      -sum(dgamma(xs, shape = shape, rate = 1, log = TRUE))
     } else if (dname == "pois") {
       lambda <- clip(exp(par[1] + par[2] * pred), EPS, 1e6)
       -sum(dpois(xs, lambda = lambda, log = TRUE))
@@ -46,6 +49,31 @@ nll_fun_from_cfg <- function(k, cfg) {
   }
 }
 
+grad_nll_from_cfg <- function(k, cfg) {
+  dname <- cfg[[k]]$distr
+  function(par, xs, Xprev) {
+    pred <- if (k > 1) Xprev[, k - 1] else 0
+    if (dname == "norm") {
+      mu <- par[1] + par[2] * pred
+      g1 <- sum(mu - xs)
+      g2 <- sum((mu - xs) * pred)
+    } else if (dname == "exp") {
+      rate <- clip(exp(par[1] + par[2] * pred), EPS, 1e6)
+      g_common <- rate * xs - 1
+      g1 <- sum(g_common)
+      g2 <- sum(g_common * pred)
+    } else if (dname == "gamma") {
+      shape <- clip(par[1] + par[2] * pred, EPS, 1e6)
+      g_common <- digamma(shape) - log(xs)
+      g1 <- sum(g_common)
+      g2 <- sum(g_common * pred)
+    } else {
+      stop("gradient not implemented")
+    }
+    c(g1, g2)
+  }
+}
+
 ## Evaluate fitted densities ------------------------------------------------
 eval_ll_from_cfg <- function(k, pars, X, cfg) {
   xs    <- X[, k]
@@ -58,6 +86,9 @@ eval_ll_from_cfg <- function(k, pars, X, cfg) {
   } else if (dname == "exp") {
     rate <- clip(exp(pars[1] + pars[2] * pred), EPS, 1e6)
     dexp(xs, rate = rate, log = TRUE)
+  } else if (dname == "gamma") {
+    shape <- clip(pars[1] + pars[2] * pred, EPS, 1e6)
+    dgamma(xs, shape = shape, rate = 1, log = TRUE)
   } else if (dname == "pois") {
     lambda <- clip(exp(pars[1] + pars[2] * pred), EPS, 1e6)
     dpois(xs, lambda = lambda, log = TRUE)
@@ -85,7 +116,17 @@ fit_param <- function(X_pi_train, X_pi_test, config) {
     xs    <- X_pi_train[, k]
     Xprev <- if (k > 1) X_pi_train[, 1:(k - 1), drop = FALSE] else NULL
     nll   <- nll_fun_from_cfg(k, config)
-    fit   <- safe_optim(init_vals[[k]], nll, xs = xs, Xprev = Xprev)
+    method <- if (config[[k]]$distr %in% c("gamma", "beta")) "L-BFGS-B" else "BFGS"
+    lower <- if (method == "L-BFGS-B") rep(EPS, length(init_vals[[k]])) else -Inf
+    fit   <- safe_optim(init_vals[[k]], nll, xs = xs, Xprev = Xprev,
+                        method = method, lower = lower)
+    if (method == "L-BFGS-B") {
+      grad_fun <- grad_nll_from_cfg(k, config)
+      ana_g <- grad_fun(fit$par, xs = xs, Xprev = Xprev)
+      num_g <- numDeriv::grad(nll, fit$par, xs = xs, Xprev = Xprev)
+      diff_g <- max(abs(ana_g - num_g))
+      message(sprintf("grad check dim %d diff %.3e", k, diff_g))
+    }
     param_est[[k]] <- fit$par
 
     pll <- sum(eval_ll_from_cfg(k, param_est[[k]], X_pi_train, config))
@@ -97,6 +138,7 @@ fit_param <- function(X_pi_train, X_pi_test, config) {
     if (!is.finite(delta_ll)) {
       warning(sprintf("non-finite delta_ll in dimension %d", k))
     }
+    stopifnot(abs(delta_ll) < 1e4)
   }
 
   true_ll_mat_test <- sapply(seq_len(K), function(k)
@@ -139,6 +181,8 @@ summarise_fit <- function(param_est, X_test, ll_delta_df, cfg = config) {
     dname <- cfg[[k]]$distr
     if (dname %in% c("exp", "pois")) {
       mean(clip(exp(param_est[[k]][1] + param_est[[k]][2] * pred), EPS, 1e6))
+    } else if (dname == "gamma") {
+      mean(clip(param_est[[k]][1] + param_est[[k]][2] * pred, EPS, 1e6))
     } else {
       mean(param_est[[k]][1] + param_est[[k]][2] * pred)
     }

--- a/run3.R
+++ b/run3.R
@@ -1,6 +1,6 @@
 N <- 500
-# Choose which configuration to use: 3 or 4
-config_choice <- 4
+# fixed three-dimensional setup
+config_choice <- 3
 Sys.setenv(N_train = N, N_test = N)
 
 source("00_setup.R")


### PR DESCRIPTION
## Summary
- adapt `config3` to use norm, exp, gamma
- support gamma distribution in parametric baseline
- add gradient checks and L-BFGS-B optimisation
- set fixed 3-dim configuration in `run3.R`

## Testing
- `bash lint.sh`
- `Rscript basic_tests.R`
- `Rscript -e "testthat::test_dir('tests/testthat')"`
- `Rscript run3.R`