### PR TITLE
Fix code dump for run3

### DIFF
--- a/dump_run3_code.R
+++ b/dump_run3_code.R
@@ -1,4 +1,10 @@
-files <- c("00_setup.R", "01_transport_utils.R", "02_generate_data.R", "03_param_baseline.R")
+files <- c(
+  "00_setup.R",
+  "01_transport_utils.R",
+  "02_generate_data.R",
+  "03_param_baseline.R",
+  "run3.R"
+)
 code_lines <- lapply(files, function(f) {
   lines <- readLines(f)
   lines <- gsub("#.*$", "", lines)


### PR DESCRIPTION
## Summary
- include `run3.R` in the list of files dumped by `dump_run3_code.R`

## Testing
- `sh run_checks.sh`