### PR TITLE
Fix code dump for run5

### DIFF
--- a/dump_run3_code.R
+++ b/dump_run3_code.R
@@ -1,4 +1,10 @@
-files <- c("00_setup.R", "01_transport_utils.R", "02_generate_data.R", "03_param_baseline.R")
+files <- c(
+  "00_setup.R",
+  "01_transport_utils.R",
+  "02_generate_data.R",
+  "03_param_baseline.R",
+  "run3.R"
+)
 code_lines <- lapply(files, function(f) {
   lines <- readLines(f)
   lines <- gsub("#.*$", "", lines)

--- a/dump_run5_code.R
+++ b/dump_run5_code.R
@@ -5,7 +5,8 @@ files <- c(
   "03_param_baseline.R",
   "04_forest_models.R",
   "06_kernel_smoothing.R",
-  "05_joint_evaluation.R"
+  "05_joint_evaluation.R",
+  "run5.R"
 )
 code_lines <- lapply(files, function(f) {
   lines <- readLines(f)


### PR DESCRIPTION
## Summary
- include `run5.R` in the list of files dumped by `dump_run5_code.R`

## Testing
- `bash run_checks.sh`
