### PR TITLE
Ensure consistent seeding and remove unused counters

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -4,7 +4,6 @@
 # Ausgabe: `config`, `K`, Funktionen wie `clip()` und `logsumexp()`
 # Notation siehe Notation.md
 SEED <- 24
-set.seed(SEED)
 suppressPackageStartupMessages({
   library(extraDistr)
   library(tram)

--- a/01_transport_utils.R
+++ b/01_transport_utils.R
@@ -7,8 +7,6 @@
 #   2. U_eta durch `qtf_k` mappen, logd sammeln
 # Map ist monoton, daher invertierbar
 
-SAFE_PAR_COUNT <- 0
-SAFE_SUPPORT_COUNT <- 0
 
 clip_count <- function(x, lo, hi) {
   changed <- (x < lo) | (x > hi)
@@ -20,23 +18,19 @@ safe_pars <- function(pars, dname) {
   hi <- 1e6
   if (dname == "norm" && !is.null(pars$sd)) {
     res <- clip_count(pars$sd, lo, hi)
-    SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
     pars$sd <- res$val
   }
   if (dname == "exp" && !is.null(pars$rate)) {
     res <- clip_count(pars$rate, lo, hi)
-    SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
     pars$rate <- res$val
   }
   if (dname == "gamma") {
     if (!is.null(pars$shape)) {
       res <- clip_count(pars$shape, lo, hi)
-      SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
       pars$shape <- res$val
     }
     if (!is.null(pars$rate)) {
       res <- clip_count(pars$rate, lo, hi)
-      SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
       pars$rate <- res$val
     }
   }
@@ -44,50 +38,41 @@ safe_pars <- function(pars, dname) {
   if (dname == "weibull") {
     if (!is.null(pars$shape)) {
       res <- clip_count(pars$shape, lo, hi)
-      SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
       pars$shape <- res$val
     }
     if (!is.null(pars$scale)) {
       res <- clip_count(pars$scale, lo, hi)
-      SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
       pars$scale <- res$val
     }
   }
   if (dname == "lnorm" && !is.null(pars$sdlog)) {
     res <- clip_count(pars$sdlog, lo, hi)
-    SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
     pars$sdlog <- res$val
   }
   if (dname == "pois" && !is.null(pars$lambda)) {
     res <- clip_count(pars$lambda, lo, hi)
-    SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
     pars$lambda <- res$val
   }
   if (dname %in% c("bern", "binom") && !is.null(pars$prob)) {
     changed <- (pars$prob < lo) | (pars$prob > 1 - lo)
-    SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + sum(changed)
     pars$prob <- pmin(1 - lo, pmax(lo, pars$prob))
   }
   if (dname == "binom" && !is.null(pars$size)) {
     res <- clip_count(pars$size, 1, hi)
-    SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
     pars$size <- res$val
   }
   if (dname == "beta") {
     if (!is.null(pars$shape1)) {
       res <- clip_count(pars$shape1, lo, hi)
-      SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
       pars$shape1 <- res$val
     }
     if (!is.null(pars$shape2)) {
       res <- clip_count(pars$shape2, lo, hi)
-      SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
       pars$shape2 <- res$val
     }
   }
   if (dname == "logis" && !is.null(pars$scale)) {
     res <- clip_count(pars$scale, lo, hi)
-    SAFE_PAR_COUNT <<- SAFE_PAR_COUNT + res$count
     pars$scale <- res$val
   }
   pars
@@ -111,7 +96,6 @@ safe_support <- function(x, dname, pars = list()) {
     },
     x
   )
-  SAFE_SUPPORT_COUNT <<- SAFE_SUPPORT_COUNT + sum(old != res)
   res
 }
 

--- a/02_generate_data.R
+++ b/02_generate_data.R
@@ -13,7 +13,6 @@
 
 source("01_transport_utils.R")
 
-set.seed(2044)
 N_train <- as.integer(Sys.getenv("N_train", "500"))
 samp_train <- pi_sample(N_train)
 X_pi_train <- samp_train$X_pi
@@ -23,8 +22,6 @@ logd_train <- samp_train$logd
 
 logdet_J_train <- logdet_J(logd_train)
 ll_train <- loglik(Z_eta_train, logdet_J_train)
-
-set.seed(2045)
 N_test <- as.integer(Sys.getenv("N_test", "500"))
 samp_test <- pi_sample(N_test)
 X_pi_test <- samp_test$X_pi

--- a/03_param_baseline.R
+++ b/03_param_baseline.R
@@ -107,8 +107,6 @@ eval_ll_from_cfg <- function(k, pars, X, cfg) {
 }
 
 fit_param <- function(X_pi_train, X_pi_test, config) {
-  SAFE_PAR_COUNT <<- 0
-  SAFE_SUPPORT_COUNT <<- 0
 
   init_vals <- replicate(K, c(0, 0), simplify = FALSE)
   param_est <- vector("list", K)
@@ -167,9 +165,7 @@ fit_param <- function(X_pi_train, X_pi_test, config) {
     param_est = param_est,
     ll_delta_df_test = ll_delta_df_test,
     true_ll_mat_test = true_ll_mat_test,
-    param_ll_mat_test = param_ll_mat_test,
-    SAFE_PAR_COUNT = SAFE_PAR_COUNT,
-    SAFE_SUPPORT_COUNT = SAFE_SUPPORT_COUNT
+    param_ll_mat_test = param_ll_mat_test
   )
 }
 

--- a/04_forest_models.R
+++ b/04_forest_models.R
@@ -11,7 +11,6 @@
 library(trtf)
 
 fit_forest <- function(X_pi_train, X_pi_test) {
-  set.seed(2046)
   data <- as.data.frame(X_pi_train)
   ymod <- lapply(names(data), function(y)
     BoxCox(as.formula(paste0(y, "~1")), data = data)

--- a/run3.R
+++ b/run3.R
@@ -9,6 +9,7 @@ config_choice <- 3
 Sys.setenv(N_train = N, N_test = N)
 
 source("00_setup.R")
+set.seed(SEED)
 source("01_transport_utils.R")
 source("02_generate_data.R")
 

--- a/run5.R
+++ b/run5.R
@@ -8,12 +8,11 @@
 #   3. Loglikelihood-Abweichungen zusammenfassen und visualisieren
 
 N <- 50
-SEED <- 2023
 
 Sys.setenv(N_train = N, N_test = N)
 
 source("00_setup.R")
-set.seed(SEED)  # Seed hier überschreiben
+set.seed(SEED)
 config <- config4
 K <- length(config)
 


### PR DESCRIPTION
## Summary
- remove per-script seeds so the global seed from `00_setup.R` is used
- call `set.seed(SEED)` once in `run3.R` and `run5.R`
- drop obsolete `SAFE_PAR_COUNT` and `SAFE_SUPPORT_COUNT` logic

## Testing
- `bash run_checks.sh`