### PR TITLE
Enhance dump_run3_code markers

### DIFF
--- a/dump_run3_code.R
+++ b/dump_run3_code.R
@@ -9,14 +9,15 @@ code_lines <- lapply(files, function(f) {
   lines <- readLines(f)
   lines <- gsub("#.*$", "", lines)
   lines <- trimws(lines)
-  lines[nzchar(lines)]
+  lines <- lines[nzchar(lines)]
+  c(paste0("###start_", f, "###"), lines, paste0("###end_", f, "###"))
 })
 code_text <- unlist(code_lines)
 if (!dir.exists("results")) dir.create("results")
 out_file <- file.path("results", "code_and_output.txt")
 writeLines(code_text, out_file)
 
-output_lines <- capture.output({
+output_lines <- c("###start_output_run3.R###", capture.output({
   cat("Train EDA:\n")
   cat("- X_pi_train Mean: ", paste(round(colMeans(X_train), 3), collapse = ", "), "\n")
   cat("- X_pi_train SD:   ", paste(round(apply(X_train, 2, sd), 3), collapse = ", "), "\n")
@@ -31,7 +32,7 @@ output_lines <- capture.output({
   print(ll_delta_df_test[
     , c("dim", "distribution", "ll_true_avg", "ll_param_avg", "delta_ll_param_avg", "mean_param_test", "mle_param")
   ])
-})
+}), "###end_output_run3.R###")
 con <- file(out_file, open = "a")
 writeLines(output_lines, con)
 close(con)


### PR DESCRIPTION
## Summary
- add explicit start/end markers in `dump_run3_code.R`
- wrap output section with markers

## Testing
- `bash run_checks.sh`