### PR TITLE
Remove redundant code and streamline output

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -12,20 +12,6 @@ softplus <- function(x) {
 
 EPS <- 1e-10
 
-logsumexp <- function(x) {
-  stopifnot(is.numeric(x))
-  m <- max(x)
-  res <- m + log(sum(exp(x - m)))
-  stopifnot(is.finite(res))
-  res
-}
-
-safe_logdens <- function(val, eps = EPS, hi = 1e6) {
-  res <- log(pmin(pmax(val, eps), hi))
-  stopifnot(all(is.finite(res)))
-  res
-}
-
 safe_cdf <- function(val, eps = EPS) {
   res <- pmax(eps, pmin(1 - eps, val))
   stopifnot(all(is.finite(res)))

--- a/dump_run3_code.R
+++ b/dump_run3_code.R
@@ -17,22 +17,9 @@ if (!dir.exists("results")) dir.create("results")
 out_file <- file.path("results", "code_and_output.txt")
 writeLines(code_text, out_file)
 
-output_lines <- c("###start_output_run3.R###", capture.output({
-  cat("Train EDA:\n")
-  cat("- X_pi_train Mean: ", paste(round(colMeans(X_train), 3), collapse = ", "), "\n")
-  cat("- X_pi_train SD:   ", paste(round(apply(X_train, 2, sd), 3), collapse = ", "), "\n")
-  cat("- log_det(J)_train Range: [", round(min(train_df$det_J), 3), ",", round(max(train_df$det_J), 3), "]\n\n")
-
-  cat("Test EDA:\n")
-  cat("- X_pi_test Mean: ", paste(round(colMeans(X_test), 3), collapse = ", "), "\n")
-  cat("- X_pi_test SD:   ", paste(round(apply(X_test, 2, sd), 3), collapse = ", "), "\n")
-  cat("- log_det(J)_test Range: [", round(min(test_df$det_J), 3), ",", round(max(test_df$det_J), 3), "]\n\n")
-
-  print(summary_stats)
-  print(ll_delta_df_test[
-    , c("dim", "distribution", "ll_true_avg", "ll_param_avg", "delta_ll_param_avg", "mean_param_test", "mle_param")
-  ])
-}), "###end_output_run3.R###")
+output_lines <- c("###start_output_run3.R###",
+  capture.output(source("run3.R", echo = FALSE)),
+  "###end_output_run3.R###")
 con <- file(out_file, open = "a")
 writeLines(output_lines, con)
 close(con)

--- a/run3.R
+++ b/run3.R
@@ -47,13 +47,9 @@ param_res <- fit_param(X_pi_train, X_pi_test, config)
 param_est <- param_res$param_est
 ll_delta_df_test <- summarise_fit(param_est, X_pi_test, param_res$ll_delta_df_test, config)
 
-ll_delta_df_test$delta_ll_param_avg <-
-  ll_delta_df_test$ll_true_avg - ll_delta_df_test$ll_param_avg
-
 print(ll_delta_df_test[
   , c(
     "dim", "distribution", "ll_true_avg", "ll_param_avg", "delta_ll_param_avg",
     "mean_param_test", "mle_param"
   )
 ])
-source("dump_run3_code.R")


### PR DESCRIPTION
## Summary
- clean up unused functions in `00_setup.R`
- avoid duplicate delta log-likelihood calculation in `run3.R`
- stop `run3.R` from sourcing `dump_run3_code.R`
- rewrite `dump_run3_code.R` to capture output by sourcing `run3.R`

## Testing
- `bash run_checks.sh`