### PR TITLE
Fix dump file generation

### DIFF
--- a/dump_run3_code.R
+++ b/dump_run3_code.R
@@ -1,3 +1,19 @@
+files <- c(
+  "00_setup.R",
+  "01_transport_utils.R",
+  "02_generate_data.R",
+  "03_param_baseline.R",
+  "run3.R"
+)
+code_lines <- lapply(files, function(f) {
+  lines <- readLines(f)
+  lines <- gsub("#.*$", "", lines)
+  lines <- trimws(lines)
+  lines <- lines[nzchar(lines)]
+  c(paste0("###start_", f, "###"), lines, paste0("###end_", f, "###"))
+})
+code_text <- unlist(code_lines)
+if (!dir.exists("results")) dir.create("results")
 out_file <- file.path("results", "code_and_output.txt")
 writeLines(code_text, out_file)
 

--- a/run3.R
+++ b/run3.R
@@ -53,3 +53,5 @@ print(ll_delta_df_test[
     "mean_param_test", "mle_param"
   )
 ])
+
+source("dump_run3_code.R")


### PR DESCRIPTION
## Summary
- restore code extraction logic in `dump_run3_code.R`
- call `dump_run3_code.R` at the end of `run3.R` so running the script again writes `results/code_and_output.txt`

## Testing
- `bash run_checks.sh`