### PR TITLE
Implement detailed comparison export

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -87,5 +87,6 @@ K <- length(config)
 source("01_map_definition_S.R")
 source("02_sampling.R")
 source("03_param_baseline.R")
+source("04_evaluation_diagnostics.R")
 
 dist_registry <- make_dist_registry()

--- a/tests/testthat/test_detailed_comparison.R
+++ b/tests/testthat/test_detailed_comparison.R
@@ -1,0 +1,21 @@
+library(testthat)
+source("../../00_setup.R", chdir = TRUE)
+
+test_that("save_detailed_comparison_data outputs CSV", {
+  set.seed(42)
+  data <- generate_data(N_train = 10, N_test = 10)
+  X <- data$train$sample$X_pi
+  param_ests <- lapply(seq_len(K), function(k) {
+    family_spec <- dist_registry[[config[[k]]$distr]]
+    n_par <- length(family_spec$param_names)
+    rep(0, n_par * if (k == 1) 1 else (k - 1) + 1)
+  })
+  tmp <- tempfile()
+  dir.create(tmp)
+  save_detailed_comparison_data(X, param_ests, config, dist_registry, tmp, "train")
+  f1 <- file.path(tmp, paste0("dim1_", config[[1]]$distr, "_params_logpdf_train.csv"))
+  expect_true(file.exists(f1))
+  df <- read.csv(f1)
+  expect_equal(nrow(df), nrow(X))
+  expect_false(any(is.na(df)))
+})


### PR DESCRIPTION
## Summary
- add `save_detailed_comparison_data` function to export per-observation parameter and log-density tables
- source evaluation utilities in setup
- test that CSV export works

## Testing
- `bash run_checks.sh`