### PR TITLE
Add diagnostic run function and integrate in run3

### DIFF
--- a/04_evaluation_diagnostics.R
+++ b/04_evaluation_diagnostics.R
@@ -106,3 +106,16 @@ save_detailed_comparison_data <- function(data_matrix, param_ests_list,
   }
 }
 
+
+run_all_diagnostics <- function(X_train, X_test, param_ests, config_list,
+                                dist_registry_obj, output_dir_base) {
+  save_estimated_betas(param_ests, config_list,
+                       dist_registry_obj, output_dir_base)
+  save_detailed_comparison_data(X_train, param_ests, config_list,
+                                dist_registry_obj, output_dir_base,
+                                data_label_str = "train")
+  save_detailed_comparison_data(X_test, param_ests, config_list,
+                                dist_registry_obj, output_dir_base,
+                                data_label_str = "test")
+  message(sprintf("Diagnostic CSVs for analysis saved to: %s", output_dir_base))
+}

--- a/run3.R
+++ b/run3.R
@@ -7,6 +7,7 @@ config_choice <- 3
 Sys.setenv(N_train = N, N_test = N)
 
 source("00_setup.R")
+source("04_evaluation_diagnostics.R")
 set.seed(SEED)
 data <- generate_data()
 write_data(data)
@@ -53,5 +54,9 @@ print(ll_delta_df_test[
     "mean_param_test", "mle_param"
   )
 ])
+
+diagnostics_dir <- "diagnostics_output"
+run_all_diagnostics(X_pi_train, X_pi_test, param_est,
+                    config, dist_registry, diagnostics_dir)
 
 source("dump_run3_code.R")


### PR DESCRIPTION
## Summary
- add `run_all_diagnostics` helper wrapping beta and logpdf exports
- call new helper from `run3.R` after fitting
- ensure diagnostics script is sourced explicitly in `run3.R`

## Testing
- `bash run_checks.sh`