### PR TITLE
Implement new summary_table

### DIFF
--- a/run3.R
+++ b/run3.R
@@ -45,12 +45,18 @@ print(summary_stats)
 
 param_res <- fit_param(X_pi_train, X_pi_test, config)
 param_est <- param_res$param_est
-ll_delta_df_test <- summarise_fit(param_est, X_pi_test, param_res$ll_delta_df_test, config)
+tbl <- summary_table(
+  X_pi_train,
+  config,
+  param_est,
+  param_res$ll_delta_df_test$ll_true_avg,
+  param_res$ll_delta_df_test$ll_param_avg
+)
 
-print(ll_delta_df_test[
+print(tbl[
   , c(
-    "dim", "distribution", "ll_true_avg", "ll_param_avg", "delta_ll_param_avg",
-    "mean_param_test", "mle_param"
+    "dim", "distr", "ll_true_avg", "ll_param_avg", "delta",
+    "mean_param1", "mean_param2", "mle_param1", "mle_param2"
   )
 ])
 


### PR DESCRIPTION
## Notes
- Adapted workflow comment for `summary_table`
- Replaced `summarise_fit` with `summary_table` and expanded logic
- Updated `run3.R` to use new summary table function

## Summary
- `summary_table` now computes per-dimension parameter means and MLEs using training data
- Workflow documentation updated with detailed steps for computing these metrics
- Example run updated to print additional columns

## Testing
- `bash lint.sh`
- `Rscript -e "testthat::test_dir('tests/testthat')"`
- `bash run_checks.sh` *(fails: cannot open file 'basic_tests.R')*