### PR TITLE
Refactor config setup and update tests

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -75,12 +75,8 @@ safe_support <- function(x, dname, pars = list()) {
   x
 }
 
-config <- list(
-  list(distr = "norm", parm = NULL),
-  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
-  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
-)
-
+if (!exists("config"))
+  stop("config must be defined before sourcing 00_setup.R")
 
 K <- length(config)
 

--- a/basic_tests.R
+++ b/basic_tests.R
@@ -1,3 +1,9 @@
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
+  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+)
+
 source("00_setup.R")
 set.seed(123)
 dat <- generate_data(N_total = 10)

--- a/run3.R
+++ b/run3.R
@@ -1,10 +1,15 @@
 
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
+  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1))),
+  list(distr = "beta",  parm  = function(d) list(shape1 = softplus(d$X1) + 2, shape2 = softplus(d$X3) + 1))
+)
 
 N <- 50
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) > 0 && args[1] == "big") N <- 10000
 
-config_choice <- 3
 Sys.setenv(N_total = N)
 
 source("00_setup.R")

--- a/tests/testthat/test_edgecases.R
+++ b/tests/testthat/test_edgecases.R
@@ -1,4 +1,9 @@
 library(testthat)
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
+  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+)
 source("../../00_setup.R", chdir = TRUE)
 
 # Extreme X_k values should not produce NaN log-densities

--- a/tests/testthat/test_fit_param.R
+++ b/tests/testthat/test_fit_param.R
@@ -2,7 +2,11 @@ library(testthat)
 
 set.seed(123)
 Sys.setenv(N_total = 1000)
-config_choice <- 3
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
+  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+)
 source("../../00_setup.R", chdir = TRUE)
 data <- generate_data()
 X_pi_train <- data$train$sample$X_pi

--- a/tests/testthat/test_logp_table.R
+++ b/tests/testthat/test_logp_table.R
@@ -1,4 +1,9 @@
 library(testthat)
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
+  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+)
 source("../../00_setup.R", chdir = TRUE)
 
 test_that("all config distributions in logp table", {

--- a/tests/testthat/test_softplus_gamma.R
+++ b/tests/testthat/test_softplus_gamma.R
@@ -1,4 +1,9 @@
 library(testthat)
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
+  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+)
 source("../../00_setup.R", chdir = TRUE)
 
 # Softplus positivity


### PR DESCRIPTION
## Summary
- move global `config` out of `00_setup.R`
- provide default config at start of `run3.R`
- adjust basic tests and testthat suite to define `config`
- extend sample run with a Beta component

## Testing
- `bash run_checks.sh`
- `Rscript run3.R > /tmp/run3.log`