### PR TITLE
Fix cdf_k log CDF

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -18,6 +18,14 @@ safe_cdf <- function(val, eps = EPS) {
   res
 }
 
+safe_logcdf <- function(val, eps = EPS) {
+  lo <- log(eps)
+  hi <- log1p(-eps)
+  res <- pmax(lo, pmin(hi, val))
+  stopifnot(all(is.finite(res)))
+  res
+}
+
 safe_pars <- function(pars, dname) {
   if (dname == "norm" && !is.null(pars$sd)) stopifnot(all(pars$sd > 0))
   if (dname == "exp"  && !is.null(pars$rate)) stopifnot(all(pars$rate > 0))
@@ -56,6 +64,8 @@ q_supports_logp <- c(
   sn      = TRUE
 )
 
+p_supports_logp <- q_supports_logp
+
 safe_support <- function(x, dname, pars = list()) {
   valid <- switch(dname,
     exp     = x > 0,
@@ -80,8 +90,8 @@ if (!exists("config"))
 
 K <- length(config)
 
-source("01_map_definition_S.R")
-source("02_sampling.R")
-source("03_baseline.R")
+source("01_map_definition_S.R", local = TRUE)
+source("02_sampling.R", local = TRUE)
+source("03_baseline.R", local = TRUE)
 
 dist_registry <- make_dist_registry()

--- a/01_map_definition_S.R
+++ b/01_map_definition_S.R
@@ -26,12 +26,23 @@ cdf_k <- function(k, xk, x_prev, cfg, log = TRUE) {
   dname <- cfg[[k]]$distr
   pars  <- get_pars(k, x_prev, cfg)
   xk    <- safe_support(xk, dname, pars)
-  args  <- c(if (dname == "sn") list(x = xk) else list(q = xk),
-             pars,
-             list(log.p = FALSE))
-  cdfv <- do.call(dist_fun("p", dname), args)
-  cdfv <- safe_cdf(cdfv)
-  if (log) log(cdfv) else cdfv
+  support <- p_supports_logp[dname]
+  if (is.na(support))
+    stop("log.p capability not specified for distribution ", dname)
+  if (log && support) {
+    args <- c(if (dname == "sn") list(x = xk) else list(q = xk),
+              pars,
+              list(log.p = TRUE))
+    cdfv <- do.call(dist_fun("p", dname), args)
+    safe_logcdf(cdfv)
+  } else {
+    args <- c(if (dname == "sn") list(x = xk) else list(q = xk),
+              pars,
+              list(log.p = FALSE))
+    cdfv <- do.call(dist_fun("p", dname), args)
+    cdfv <- safe_cdf(cdfv)
+    if (log) log(cdfv) else cdfv
+  }
 }
 
 qtf_k <- function(k, u, x_prev, cfg, log.p = FALSE) {

--- a/06_kernel_smoothing.R
+++ b/06_kernel_smoothing.R
@@ -10,6 +10,21 @@
 #       - gewichtete Dichte berechnen
 #       - Logdichte via `safe_logdens()` speichern
 
+if (!exists("logsumexp")) {
+  logsumexp <- function(x) {
+    m <- max(x)
+    m + log(sum(exp(x - m)))
+  }
+}
+
+if (!exists("safe_logdens")) {
+  safe_logdens <- function(dens, eps = EPS) {
+    res <- pmax(log(eps), log(dens))
+    stopifnot(all(is.finite(res)))
+    res
+  }
+}
+
 fit_kernel <- function(data) {
   N <- nrow(data)
   K <- ncol(data)

--- a/tests/testthat/test_cdf_log.R
+++ b/tests/testthat/test_cdf_log.R
@@ -1,0 +1,23 @@
+library(testthat)
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp", parm = function(d) list(rate = softplus(d$X1)))
+)
+source("../../00_setup.R", chdir = TRUE, local = TRUE)
+
+# check log output
+
+test_that("cdf_k uses log.p when supported", {
+  val <- 0.2
+  expect_equal(cdf_k(1, val, numeric(0), config, log = TRUE),
+               pnorm(val, log.p = TRUE))
+  rate <- softplus(0.5)
+  expect_equal(cdf_k(2, val, 0.5, config, log = TRUE),
+               pexp(val, rate = rate, log.p = TRUE))
+})
+
+test_that("cdf_k returns probabilities when log = FALSE", {
+  val <- 0.3
+  expect_equal(cdf_k(1, val, numeric(0), config, log = FALSE),
+               pnorm(val, log.p = FALSE))
+})

--- a/tests/testthat/test_logp_table.R
+++ b/tests/testthat/test_logp_table.R
@@ -9,4 +9,5 @@ source("../../00_setup.R", chdir = TRUE)
 test_that("all config distributions in logp table", {
   names <- sapply(config, `[[`, "distr")
   expect_true(all(names %in% names(q_supports_logp)))
+  expect_true(all(names %in% names(p_supports_logp)))
 })


### PR DESCRIPTION
## Summary
- add `safe_logcdf` to clamp log-CDF values
- list distributions supporting `log.p` for CDF
- use log CDF directly in `cdf_k`
- provide fallbacks for kernel code
- add regression tests for log CDF

## Testing
- `bash run_checks.sh`