### PR TITLE
Update evaluation summary column names

### DIFF
--- a/03_baseline.R
+++ b/03_baseline.R
@@ -186,12 +186,12 @@ fit_param <- function(X_pi_train, X_pi_test, config, registry = dist_registry) {
   })
   ll_delta_df_test <- data.frame(
     dim = seq_len(K),
-    distribution = sapply(config, `[[`, "distr"),
-    ll_true_avg = apply(true_ll_mat_test, 2, mean),
-    ll_param_avg = colMeans(param_ll_mat_test)
+    distr = sapply(config, `[[`, "distr"),
+    ll_true = apply(true_ll_mat_test, 2, mean),
+    ll_param = colMeans(param_ll_mat_test)
   )
-  ll_delta_df_test$delta_ll_param_avg <-
-    ll_delta_df_test$ll_true_avg - ll_delta_df_test$ll_param_avg
+  ll_delta_df_test$delta_ll_param <-
+    ll_delta_df_test$ll_true - ll_delta_df_test$ll_param
   ll_delta_df_test[, 3:5] <- round(ll_delta_df_test[, 3:5], 6)
   list(param_est = param_est,
        ll_delta_df_test = ll_delta_df_test,

--- a/05_joint_evaluation.R
+++ b/05_joint_evaluation.R
@@ -39,13 +39,13 @@ kernel_df$delta <- kernel_df$ell_true_avg - kernel_df$loglik_kernel
 ## Ergebnisse zusammenführen
 eval_df <- data.frame(
   dim = ll_delta_df_test$dim,
-  distribution = ll_delta_df_test$distribution,
-  ll_true_avg = ll_delta_df_test$ll_true_avg,
-  ll_param_avg = ll_delta_df_test$ll_param_avg,
-  ll_trtf_avg = forest_df$loglik_trtf,
-  ll_kernel_avg = kernel_df$loglik_kernel,
-  delta_ll_param_avg = if ("delta_ll_param_avg" %in% names(ll_delta_df_test))
-    ll_delta_df_test$delta_ll_param_avg else ll_delta_df_test$delta_ll,
+  distr = ll_delta_df_test$distr,
+  ll_true = ll_delta_df_test$ll_true,
+  ll_param = ll_delta_df_test$ll_param,
+  ll_trtf = forest_df$loglik_trtf,
+  ll_kernel = kernel_df$loglik_kernel,
+  delta_ll_param = if ("delta_ll_param" %in% names(ll_delta_df_test))
+    ll_delta_df_test$delta_ll_param else ll_delta_df_test$delta_ll,
   delta_ll_trtf = forest_df$delta,
   delta_ll_kernel = kernel_df$delta
 )
@@ -54,9 +54,9 @@ write.csv(eval_df, "results/evaluation_summary.csv", row.names = FALSE)
 plot(ld_hat, ld_true, xlab = "estimated", ylab = "true")
 abline(a = 0, b = 1)
 info_text <- sprintf(
-  "N = %d | sum(delta_ll_param_avg) = %.3f | sum(delta_ll_trtf) = %.3f | sum(delta_ll_kernel) = %.3f",
+  "N = %d | sum(delta_ll_param) = %.3f | sum(delta_ll_trtf) = %.3f | sum(delta_ll_kernel) = %.3f",
   N_test,
-  sum(eval_df$delta_ll_param_avg),
+  sum(eval_df$delta_ll_param),
   sum(eval_df$delta_ll_trtf),
   sum(eval_df$delta_ll_kernel)
 )

--- a/run3.R
+++ b/run3.R
@@ -55,8 +55,8 @@ tbl <- summary_table(
   X_pi_train,
   config,
   param_est,
-  param_res$ll_delta_df_test$ll_true_avg,
-  param_res$ll_delta_df_test$ll_param_avg
+  param_res$ll_delta_df_test$ll_true,
+  param_res$ll_delta_df_test$ll_param
 )
 
 tbl_out <- tbl[
@@ -190,8 +190,8 @@ run_pipeline <- function(N_local = N) {
     data$train$sample$X_pi,
     config,
     param_res$param_est,
-    param_res$ll_delta_df_test$ll_true_avg,
-    param_res$ll_delta_df_test$ll_param_avg
+    param_res$ll_delta_df_test$ll_true,
+    param_res$ll_delta_df_test$ll_param
   )
   print(tbl)
   invisible(tbl)

--- a/tests/testthat/test_fit_param.R
+++ b/tests/testthat/test_fit_param.R
@@ -12,7 +12,7 @@ data <- generate_data()
 X_pi_train <- data$train$sample$X_pi
 X_pi_test  <- data$test$sample$X_pi
 res <- fit_param(X_pi_train, X_pi_test, config)
-mean_delta <- mean(abs(res$ll_delta_df_test$delta_ll_param_avg))
+mean_delta <- mean(abs(res$ll_delta_df_test$delta_ll_param))
 
 test_that("parametric fit delta_ll finite", {
   expect_true(is.finite(mean_delta))

--- a/tests/testthat/test_mismatch.R
+++ b/tests/testthat/test_mismatch.R
@@ -9,7 +9,7 @@ if (file.exists('../../run5.R')) {
 test_that('joint mismatches are finite', {
   expect_true(is.finite(forest_mismatch))
   expect_true(is.finite(kernel_mismatch))
-  expect_true(all(is.finite(eval_tab$delta_ll_param_avg)))
+  expect_true(all(is.finite(eval_tab$delta_ll_param)))
   expect_true(all(is.finite(eval_tab$delta_ll_trtf)))
   expect_true(all(is.finite(eval_tab$delta_ll_kernel)))
 })


### PR DESCRIPTION
## Summary
- standardize column naming in evaluation outputs
- adapt tests and scripts to new names

## Testing
- `bash run_checks.sh`