### PR TITLE
Add bound check for delta columns in run5 output

### DIFF
--- a/tests/testthat/test_delta_bounds.R
+++ b/tests/testthat/test_delta_bounds.R
@@ -1,0 +1,16 @@
+library(testthat)
+
+if (file.exists('../../run5.R')) {
+  capture.output(source('../../run5.R', chdir = TRUE))
+} else {
+  skip('run5.R not available')
+}
+
+test_that('delta columns bounded by 1', {
+  expect_true(all(is.finite(eval_tab$delta_ll_param)))
+  expect_true(all(is.finite(eval_tab$delta_ll_trtf)))
+  expect_true(all(is.finite(eval_tab$delta_ll_kernel)))
+  expect_true(all(abs(eval_tab$delta_ll_param) <= 1))
+  expect_true(all(abs(eval_tab$delta_ll_trtf) <= 1))
+  expect_true(all(abs(eval_tab$delta_ll_kernel) <= 1))
+})


### PR DESCRIPTION
## Summary
- add new test `test_delta_bounds.R` that ensures delta columns in run5 output remain within ±1
- run `run5.R` with N=50 and confirm all delta values satisfy this bound

## Testing
- `Rscript basic_tests.R`
- `Rscript -e "testthat::test_dir('tests/testthat')"`
- `bash lint.sh`
