### PR TITLE
Automatische Linkfunktionen in config

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -95,3 +95,36 @@ source("02_sampling.R", local = TRUE)
 source("03_baseline.R", local = TRUE)
 
 dist_registry <- make_dist_registry()
+
+# zugelassene Verteilungen laut Spezifikation
+allowed_dists_full <- c(
+  "norm", "lnorm", "t", "skewt", "ged", "nig", "vargamma", "astable",
+  "exp", "weibull", "laplace", "gpd", "burrxii", "hyperbolic",
+  "invgauss", "ncchisq", "gamma", "beta"
+)
+
+# wendet die in dist_registry definierten Linkfunktionen an
+apply_links <- function(pars, dname) {
+  if (dname %in% names(dist_registry)) {
+    spec <- dist_registry[[dname]]
+    for (j in seq_along(spec$param_names)) {
+      nm <- spec$param_names[j]
+      if (!is.null(pars[[nm]]))
+        pars[[nm]] <- link_fns[[spec$link_vector[j]]](pars[[nm]])
+    }
+  }
+  pars
+}
+
+# prüft erlaubte Verteilungen und Typen
+validate_config <- function(cfg) {
+  for (ck in cfg) {
+    stopifnot(is.list(ck))
+    stopifnot(ck$distr %in% allowed_dists_full)
+    if (!is.null(ck$parm))
+      stopifnot(is.function(ck$parm))
+  }
+  cfg
+}
+
+config <- validate_config(config)

--- a/01_map_definition_S.R
+++ b/01_map_definition_S.R
@@ -11,6 +11,7 @@ get_pars <- function(k, x_prev, cfg) {
     x_df <- as.data.frame(x_prev)
   }
   pars <- ck$parm(x_df)
+  pars <- apply_links(pars, ck$distr)
   safe_pars(pars, ck$distr)
 }
 

--- a/basic_tests.R
+++ b/basic_tests.R
@@ -1,7 +1,7 @@
 config <- list(
   list(distr = "norm", parm = NULL),
-  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
-  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+  list(distr = "exp",  parm = function(d) list(rate = d$X1)),
+  list(distr = "gamma", parm  = function(d) list(shape = d$X2, rate = d$X1))
 )
 
 source("00_setup.R")

--- a/run3.R
+++ b/run3.R
@@ -1,8 +1,8 @@
 
 config <- list(
   list(distr = "norm", parm = NULL),
-  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
-  list(distr = "beta", parm  = function(d) list(shape1 = softplus(d$X2), shape2 = 1))
+  list(distr = "exp",  parm = function(d) list(rate = d$X1)),
+  list(distr = "beta", parm  = function(d) list(shape1 = d$X2, shape2 = 1))
 )
 
 N <- 50

--- a/run5.R
+++ b/run5.R
@@ -2,8 +2,8 @@
 
 config <- list(
   list(distr = "norm", parm = NULL),
-  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
-  list(distr = "beta", parm  = function(d) list(shape1 = softplus(d$X2), shape2 = 1))
+  list(distr = "exp",  parm = function(d) list(rate = d$X1)),
+  list(distr = "beta", parm  = function(d) list(shape1 = d$X2, shape2 = 1))
 )
 
 N <- 50

--- a/tests/testthat/test_cdf_log.R
+++ b/tests/testthat/test_cdf_log.R
@@ -1,7 +1,7 @@
 library(testthat)
 config <- list(
   list(distr = "norm", parm = NULL),
-  list(distr = "exp", parm = function(d) list(rate = softplus(d$X1)))
+  list(distr = "exp", parm = function(d) list(rate = d$X1))
 )
 source("../../00_setup.R", chdir = TRUE, local = TRUE)
 

--- a/tests/testthat/test_fit_param.R
+++ b/tests/testthat/test_fit_param.R
@@ -4,8 +4,8 @@ set.seed(123)
 Sys.setenv(N_total = 1000)
 config <- list(
   list(distr = "norm", parm = NULL),
-  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
-  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+  list(distr = "exp",  parm = function(d) list(rate = d$X1)),
+  list(distr = "gamma", parm  = function(d) list(shape = d$X2, rate = d$X1))
 )
 source("../../00_setup.R", chdir = TRUE)
 data <- generate_data()

--- a/tests/testthat/test_softplus_gamma.R
+++ b/tests/testthat/test_softplus_gamma.R
@@ -1,8 +1,8 @@
 library(testthat)
 config <- list(
   list(distr = "norm", parm = NULL),
-  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
-  list(distr = "gamma", parm  = function(d) list(shape = softplus(d$X2), rate = softplus(d$X1)))
+  list(distr = "exp",  parm = function(d) list(rate = d$X1)),
+  list(distr = "gamma", parm  = function(d) list(shape = d$X2, rate = d$X1))
 )
 source("../../00_setup.R", chdir = TRUE)
 


### PR DESCRIPTION
## Notes
- Fuehrt `apply_links` und `validate_config` in `00_setup.R` ein. Damit werden Parameterbereiche automatisch uebersetzt und auf erlaubte Verteilungen geprueft.
- `get_pars` ruft jetzt `apply_links` auf.
- Beispielkonfigurationen sowie Tests benutzen nun rohe Parameter ohne `softplus`.

## Testing
- `bash run_checks.sh`