### PR TITLE
Entferne safe_cdf und safe_logcdf

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -12,19 +12,6 @@ softplus <- function(x) {
 
 EPS <- 1e-10
 
-safe_cdf <- function(val, eps = EPS) {
-  res <- pmax(eps, pmin(1 - eps, val))
-  stopifnot(all(is.finite(res)))
-  res
-}
-
-safe_logcdf <- function(val, eps = EPS) {
-  lo <- log(eps)
-  hi <- log1p(-eps)
-  res <- pmax(lo, pmin(hi, val))
-  stopifnot(all(is.finite(res)))
-  res
-}
 
 safe_pars <- function(pars, dname) {
   if (dname == "norm" && !is.null(pars$sd)) stopifnot(all(pars$sd > 0))

--- a/01_map_definition_S.R
+++ b/01_map_definition_S.R
@@ -35,13 +35,11 @@ cdf_k <- function(k, xk, x_prev, cfg, log = TRUE) {
               pars,
               list(log.p = TRUE))
     cdfv <- do.call(dist_fun("p", dname), args)
-    safe_logcdf(cdfv)
   } else {
     args <- c(if (dname == "sn") list(x = xk) else list(q = xk),
               pars,
               list(log.p = FALSE))
     cdfv <- do.call(dist_fun("p", dname), args)
-    cdfv <- safe_cdf(cdfv)
     if (log) log(cdfv) else cdfv
   }
 }

--- a/cdf_logcdf_range.R
+++ b/cdf_logcdf_range.R
@@ -1,0 +1,25 @@
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = d$X1)),
+  list(distr = "beta", parm  = function(d) list(shape1 = d$X2, shape2 = 1))
+)
+
+N <- 1000
+source("00_setup.R")
+set.seed(SEED)
+data <- pi_sample(N, config)
+
+cdf_vals <- numeric(N)
+logcdf_vals <- numeric(N)
+for (i in seq_len(N)) {
+  x_prev <- data$X_pi[i, 1:2]
+  xk <- data$X_pi[i, 3]
+  cdf_vals[i] <- cdf_k(3, xk, x_prev, config, log = FALSE)
+  logcdf_vals[i] <- cdf_k(3, xk, x_prev, config, log = TRUE)
+}
+
+res <- list(
+  cdf_range = range(cdf_vals),
+  logcdf_range = range(logcdf_vals)
+)
+str(res)


### PR DESCRIPTION
## Summary
- sichere CDF-Helfer entfernt
- Anpassung in `cdf_k`
- Skript `cdf_logcdf_range.R` zum Bestimmen der CDF-/Log-CDF-Bereiche

## Testing
- `bash run_checks.sh`
