### PR TITLE
Entferne safe_pars und verschiebe Registry

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -11,8 +11,60 @@ softplus <- function(x) {
 }
 
 
-safe_pars <- function(pars, dname) {
-  pars
+link_fns <- list(identity = function(z) z, softplus = softplus)
+
+make_dist_registry <- function() {
+  reg <- list(
+    norm = list(
+      param_names = c("mu", "sigma"),
+      link_vector = c("identity", "softplus"),
+      logpdf = function(x, mu, sigma) dnorm(x, mean = mu, sd = sigma, log = TRUE),
+      invcdf = qnorm
+    ),
+    exp = list(
+      param_names = "rate",
+      link_vector = "softplus",
+      logpdf = function(x, rate) dexp(x, rate = rate, log = TRUE),
+      invcdf = qexp
+    ),
+    gamma = list(
+      param_names = c("shape", "rate"),
+      link_vector = c("softplus", "softplus"),
+      logpdf = function(x, shape, rate) dgamma(x, shape = shape, rate = rate, log = TRUE),
+      invcdf = qgamma
+    ),
+    weibull = list(
+      param_names = c("shape", "scale"),
+      link_vector = c("softplus", "softplus"),
+      logpdf = function(x, shape, scale) dweibull(x, shape = shape, scale = scale, log = TRUE),
+      invcdf = qweibull
+    ),
+    lnorm = list(
+      param_names = c("meanlog", "sdlog"),
+      link_vector = c("identity", "softplus"),
+      logpdf = function(x, meanlog, sdlog) dlnorm(x, meanlog = meanlog, sdlog = sdlog, log = TRUE),
+      invcdf = qlnorm
+    ),
+    pois = list(
+      param_names = "lambda",
+      link_vector = "softplus",
+      logpdf = function(x, lambda) dpois(x, lambda = lambda, log = TRUE),
+      invcdf = qpois
+    ),
+    beta = list(
+      param_names = c("shape1", "shape2"),
+      link_vector = c("softplus", "softplus"),
+      logpdf = function(x, shape1, shape2) dbeta(x, shape1 = shape1, shape2 = shape2, log = TRUE),
+      invcdf = qbeta
+    ),
+    logis = list(
+      param_names = c("location", "scale"),
+      link_vector = c("identity", "softplus"),
+      logpdf = function(x, location, scale) dlogis(x, location = location, scale = scale, log = TRUE),
+      invcdf = qlogis
+    )
+  )
+  reg
 }
 
 if (!exists("config"))
@@ -62,7 +114,6 @@ validate_config <- function(cfg) {
       }
       pars <- ck$parm(dummy)
       pars <- apply_links(pars, ck$distr)
-      safe_pars(pars, ck$distr)
     }
   }
   cfg

--- a/01_map_definition_S.R
+++ b/01_map_definition_S.R
@@ -12,7 +12,6 @@ get_pars <- function(k, x_prev, cfg) {
   }
   pars <- ck$parm(x_df)
   pars <- apply_links(pars, ck$distr)
-  safe_pars(pars, ck$distr)
 }
 
 pdf_k <- function(k, xk, x_prev, cfg, log = TRUE) {

--- a/03_baseline.R
+++ b/03_baseline.R
@@ -65,61 +65,6 @@ safe_optim <- function(par, fn, method = "BFGS", ...) {
   res
 }
 
-link_fns <- list(identity = function(z) z, softplus = softplus)
-
-make_dist_registry <- function() {
-  reg <- list(
-    norm = list(
-      param_names = c("mu", "sigma"),
-      link_vector = c("identity", "softplus"),
-      logpdf = function(x, mu, sigma) dnorm(x, mean = mu, sd = sigma, log = TRUE),
-      invcdf = qnorm
-    ),
-    exp = list(
-      param_names = "rate",
-      link_vector = "softplus",
-      logpdf = function(x, rate) dexp(x, rate = rate, log = TRUE),
-      invcdf = qexp
-    ),
-    gamma = list(
-      param_names = c("shape", "rate"),
-      link_vector = c("softplus", "softplus"),
-      logpdf = function(x, shape, rate) dgamma(x, shape = shape, rate = rate, log = TRUE),
-      invcdf = qgamma
-    ),
-    weibull = list(
-      param_names = c("shape", "scale"),
-      link_vector = c("softplus", "softplus"),
-      logpdf = function(x, shape, scale) dweibull(x, shape = shape, scale = scale, log = TRUE),
-      invcdf = qweibull
-    ),
-    lnorm = list(
-      param_names = c("meanlog", "sdlog"),
-      link_vector = c("identity", "softplus"),
-      logpdf = function(x, meanlog, sdlog) dlnorm(x, meanlog = meanlog, sdlog = sdlog, log = TRUE),
-      invcdf = qlnorm
-    ),
-    pois = list(
-      param_names = "lambda",
-      link_vector = "softplus",
-      logpdf = function(x, lambda) dpois(x, lambda = lambda, log = TRUE),
-      invcdf = qpois
-    ),
-    beta = list(
-      param_names = c("shape1", "shape2"),
-      link_vector = c("softplus", "softplus"),
-      logpdf = function(x, shape1, shape2) dbeta(x, shape1 = shape1, shape2 = shape2, log = TRUE),
-      invcdf = qbeta
-    ),
-    logis = list(
-      param_names = c("location", "scale"),
-      link_vector = c("identity", "softplus"),
-      logpdf = function(x, location, scale) dlogis(x, location = location, scale = scale, log = TRUE),
-      invcdf = qlogis
-    )
-  )
-  reg
-}
 
 compute_distribution_parameters <- function(theta_vector, X_prev_matrix,
                                             family_spec, N_observations) {


### PR DESCRIPTION
## Notes
- Die Hilfsfunktion `safe_pars` wurde entfernt und Aufrufe gelöscht.
- `link_fns` und `make_dist_registry` liegen nun in `00_setup.R`. Die Dopplungen in `03_baseline.R` entfallen dadurch.
- Alle Tests (`run_checks.sh`) laufen fehlerfrei.
