### PR TITLE
Verschiebe dist_fun und get_pars in Setup

### DIFF
--- a/00_setup.R
+++ b/00_setup.R
@@ -70,12 +70,6 @@ make_dist_registry <- function() {
 if (!exists("config"))
   stop("config must be defined before sourcing 00_setup.R")
 
-K <- length(config)
-
-source("01_map_definition_S.R", local = TRUE)
-source("02_sampling.R", local = TRUE)
-source("03_baseline.R", local = TRUE)
-
 dist_registry <- make_dist_registry()
 
 # zugelassene Verteilungen laut Spezifikation
@@ -96,6 +90,22 @@ apply_links <- function(pars, dname) {
     }
   }
   pars
+}
+
+dist_fun <- function(pref, name) get(paste0(pref, name))
+
+get_pars <- function(k, x_prev, cfg) {
+  ck <- cfg[[k]]
+  if (is.null(ck$parm)) return(list())
+  if (is.null(dim(x_prev))) {
+    names(x_prev) <- paste0("X", seq_along(x_prev))
+    x_df <- as.data.frame(as.list(x_prev))
+  } else {
+    colnames(x_prev) <- paste0("X", seq_len(ncol(x_prev)))
+    x_df <- as.data.frame(x_prev)
+  }
+  pars <- ck$parm(x_df)
+  pars <- apply_links(pars, ck$distr)
 }
 
 # prüft erlaubte Verteilungen und Typen
@@ -120,3 +130,8 @@ validate_config <- function(cfg) {
 }
 
 config <- validate_config(config)
+K <- length(config)
+
+source("01_map_definition_S.R", local = TRUE)
+source("02_sampling.R", local = TRUE)
+source("03_baseline.R", local = TRUE)

--- a/01_map_definition_S.R
+++ b/01_map_definition_S.R
@@ -1,18 +1,4 @@
 # Map definition functions
-dist_fun <- function(pref, name) get(paste0(pref, name))
-get_pars <- function(k, x_prev, cfg) {
-  ck <- cfg[[k]]
-  if (is.null(ck$parm)) return(list())
-  if (is.null(dim(x_prev))) {
-    names(x_prev) <- paste0("X", seq_along(x_prev))
-    x_df <- as.data.frame(as.list(x_prev))
-  } else {
-    colnames(x_prev) <- paste0("X", seq_len(ncol(x_prev)))
-    x_df <- as.data.frame(x_prev)
-  }
-  pars <- ck$parm(x_df)
-  pars <- apply_links(pars, ck$distr)
-}
 
 pdf_k <- function(k, xk, x_prev, cfg, log = TRUE) {
   pars <- get_pars(k, x_prev, cfg)


### PR DESCRIPTION
## Notes
- keine weiteren Funktionen aus `03_baseline.R` verlagert, da sie Teil des Optimierungs-Workflows sind

## Summary
- Definitionen von `dist_fun()` und `get_pars()` in `00_setup.R` integriert
- Funktionen aus `01_map_definition_S.R` entfernt und dort verwendet
- `00_setup.R` neu strukturiert: Registry, Links und Config-Validierung vor dem Einlesen der anderen Skripte

## Testing
- `bash run_checks.sh`