### PR TITLE
Reimplement baseline using joint MLE

### DIFF
--- a/03_joint_mle.R
+++ b/03_joint_mle.R
@@ -24,7 +24,7 @@ parse_param_spec <- function(config, registry) {
     )
     names_out <- c(names_out, fam_names)
   }
-  param_names_global <<- names_out
+  assign("param_names_global", names_out, envir = .GlobalEnv)
   stopifnot(all(unique(param_names_global) == param_names_global))
   invisible(param_names_global)
 }

--- a/05_joint_evaluation.R
+++ b/05_joint_evaluation.R
@@ -41,11 +41,10 @@ eval_df <- data.frame(
   dim = ll_delta_df_test$dim,
   distr = ll_delta_df_test$distr,
   ll_true = ll_delta_df_test$ll_true,
-  ll_param = ll_delta_df_test$ll_param,
+  ll_joint = ll_delta_df_test$ll_joint,
   ll_trtf = forest_df$loglik_trtf,
   ll_kernel = kernel_df$loglik_kernel,
-  delta_ll_param = if ("delta_ll_param" %in% names(ll_delta_df_test))
-    ll_delta_df_test$delta_ll_param else ll_delta_df_test$delta_ll,
+  delta_ll_joint = ll_delta_df_test$delta_joint,
   delta_ll_trtf = forest_df$delta,
   delta_ll_kernel = kernel_df$delta
 )
@@ -54,9 +53,9 @@ write.csv(eval_df, "results/evaluation_summary.csv", row.names = FALSE)
 plot(ld_hat, ld_true, xlab = "estimated", ylab = "true")
 abline(a = 0, b = 1)
 info_text <- sprintf(
-  "N = %d | sum(delta_ll_param) = %.3f | sum(delta_ll_trtf) = %.3f | sum(delta_ll_kernel) = %.3f",
+  "N = %d | sum(delta_ll_joint) = %.3f | sum(delta_ll_trtf) = %.3f | sum(delta_ll_kernel) = %.3f",
   N_test,
-  sum(eval_df$delta_ll_param),
+  sum(eval_df$delta_ll_joint),
   sum(eval_df$delta_ll_trtf),
   sum(eval_df$delta_ll_kernel)
 )

--- a/run3.R
+++ b/run3.R
@@ -49,20 +49,20 @@ summary_stats <- data.frame(
 )
 print(summary_stats)
 
-param_res <- fit_param(X_pi_train, X_pi_test, config)
-param_est <- param_res$param_est
+param_res <- fit_joint_param(X_pi_train, X_pi_test, config)
+theta_hat <- param_res$theta_hat
 tbl <- summary_table(
   X_pi_train,
   config,
-  param_est,
+  theta_hat,
   param_res$ll_delta_df_test$ll_true,
-  param_res$ll_delta_df_test$ll_param
+  param_res$ll_delta_df_test$ll_joint
 )
 
 tbl_out <- tbl[
 
   , c(
-    "dim", "distr", "ll_true_avg", "ll_base_avg", "delta_base",
+    "dim", "distr", "ll_true_avg", "ll_joint_avg", "delta_joint",
     "true_param1", "mean_param2", "mle_base1", "mle_base2"
   )
 ]
@@ -191,13 +191,13 @@ run_all_diagnostics <- function(X_train, X_test, param_ests, config_list,
 run_pipeline <- function(N_local = N) {
   Sys.setenv(N_total = N_local)
   data <- generate_data(N_total = N_local, cfg = config)
-  param_res <- fit_param(data$train$sample$X_pi, data$test$sample$X_pi, config)
+  param_res <- fit_joint_param(data$train$sample$X_pi, data$test$sample$X_pi, config)
   tbl <- summary_table(
     data$train$sample$X_pi,
     config,
-    param_res$param_est,
+    param_res$theta_hat,
     param_res$ll_delta_df_test$ll_true,
-    param_res$ll_delta_df_test$ll_param
+    param_res$ll_delta_df_test$ll_joint
   )
   print(tbl)
   invisible(tbl)

--- a/run5.R
+++ b/run5.R
@@ -32,7 +32,7 @@ run_pipeline <- function(N_local = N, cfg = config, perm = NULL) {
     X_pi_test  <<- permute_data(X_pi_test, perm)
     cfg <- cfg[perm]
   }
-  param_res <- fit_param(X_pi_train, X_pi_test, cfg)
+  param_res <- fit_joint_param(X_pi_train, X_pi_test, cfg)
   ll_delta_df_test <<- param_res$ll_delta_df_test
   true_ll_mat_test <<- param_res$true_ll_mat_test
 

--- a/tests/testthat/test_config_rules.R
+++ b/tests/testthat/test_config_rules.R
@@ -54,7 +54,7 @@ check_cfg <- function(cfg, root) {
   allowed_dists <- c(
     "norm", "lnorm", "t", "skewt",
     "exp", "weibull", "laplace", "gpd", "burrxii",
-    "invgauss", "ncchisq", "gamma", "beta"
+    "invgauss", "ncchisq", "gamma", "beta", "logis"
   )
   pos_pars <- list(
     norm    = "sigma",

--- a/tests/testthat/test_delta_bounds.R
+++ b/tests/testthat/test_delta_bounds.R
@@ -7,10 +7,10 @@ if (file.exists('../../run5.R')) {
 }
 
 test_that('delta columns bounded by 1', {
-  expect_true(all(is.finite(eval_tab$delta_ll_param)))
+  expect_true(all(is.finite(eval_tab$delta_ll_joint)))
   expect_true(all(is.finite(eval_tab$delta_ll_trtf)))
   expect_true(all(is.finite(eval_tab$delta_ll_kernel)))
-  expect_true(all(abs(eval_tab$delta_ll_param) <= 1))
+  expect_true(all(abs(eval_tab$delta_ll_joint) <= 1))
   expect_true(all(abs(eval_tab$delta_ll_trtf) <= 1))
   expect_true(all(abs(eval_tab$delta_ll_kernel) <= 2))
 })

--- a/tests/testthat/test_fit_param.R
+++ b/tests/testthat/test_fit_param.R
@@ -11,8 +11,8 @@ source("../../00_setup.R", chdir = TRUE)
 data <- generate_data()
 X_pi_train <- data$train$sample$X_pi
 X_pi_test  <- data$test$sample$X_pi
-res <- fit_param(X_pi_train, X_pi_test, config)
-mean_delta <- mean(abs(res$ll_delta_df_test$delta_ll_param))
+res <- fit_joint_param(X_pi_train, X_pi_test, config)
+mean_delta <- mean(abs(res$ll_delta_df_test$delta_joint))
 
 test_that("parametric fit delta_ll finite", {
   expect_true(is.finite(mean_delta))

--- a/tests/testthat/test_mismatch.R
+++ b/tests/testthat/test_mismatch.R
@@ -9,7 +9,7 @@ if (file.exists('../../run5.R')) {
 test_that('joint mismatches are finite', {
   expect_true(is.finite(forest_mismatch))
   expect_true(is.finite(kernel_mismatch))
-  expect_true(all(is.finite(eval_tab$delta_ll_param)))
+  expect_true(all(is.finite(eval_tab$delta_ll_joint)))
   expect_true(all(is.finite(eval_tab$delta_ll_trtf)))
   expect_true(all(is.finite(eval_tab$delta_ll_kernel)))
 })

--- a/tests/testthat/test_softplus_gamma.R
+++ b/tests/testthat/test_softplus_gamma.R
@@ -22,7 +22,11 @@ shape <- softplus(true_theta[1] + true_theta[2] * x_prev)
 rate  <- softplus(true_theta[3] + true_theta[4] * x_prev)
 xs <- rgamma(N, shape = shape, rate = rate)
 
-nll <- make_generalized_nll("gamma", matrix(x_prev, ncol = 1), xs)
+nll <- function(par) {
+  shape_hat <- softplus(par[1] + par[2] * x_prev)
+  rate_hat  <- softplus(par[3] + par[4] * x_prev)
+  -sum(dgamma(xs, shape = shape_hat, rate = rate_hat, log = TRUE))
+}
 fit <- safe_optim(rep(0, 4), nll)
 
 shape_hat <- softplus(fit$par[1] + fit$par[2] * x_prev)


### PR DESCRIPTION
## Notes
- Parametrische Baseline vollständig umgestellt auf gemeinsame Likelihood
- `fit_param()` entfernt, stattdessen `joint_loglik()` und `fit_joint_param()`
- Tests und Auswertungen auf neue Rückgabewerte angepasst

## Summary
- Globale Parameterstruktur per `parse_param_spec` und `slice_pars` neu definiert【F:03_baseline.R†L89-L142】【F:03_baseline.R†L145-L180】
- Pipelines in `run3.R` jetzt mit `fit_joint_param` und angepasster Tabelle【F:run3.R†L52-L68】
- `run5.R` nutzt ebenfalls das neue MLE-Modul【F:run5.R†L33-L39】
- Evaluation aggregiert `ll_joint` und `delta_joint` statt `ll_param`【F:05_joint_evaluation.R†L38-L59】
- Tests auf neue Spaltennamen aktualisiert【F:tests/testthat/test_delta_bounds.R†L8-L15】

## Testing
- `bash run_checks.sh`【bfa9c9†L1-L21】