### PR TITLE
Optimierung der Blockbehandlung

### DIFF
--- a/tests/testthat/test_joint_mle.R
+++ b/tests/testthat/test_joint_mle.R
@@ -6,8 +6,8 @@ config <- list(
   list(distr = "exp",  parm = function(d) list(rate = d$X1))
 )
 
-parse_param_spec(config, dist_registry)
+ps <- parse_param_spec(config, dist_registry)
 
 test_that("param names unique", {
-  expect_true(length(unique(param_names_global)) == length(param_names_global))
+  expect_true(length(unique(ps$param_names)) == length(ps$param_names))
 })


### PR DESCRIPTION
## Notes
- parse_param_spec liefert nun Namen und Dimensionen zurück, kein globales Objekt mehr.
- fit_joint_param nutzt Blockindices und sinnvolle Startwerte.
- summary_table verarbeitet jetzt Blockdimensionen.
- Test angepasst auf neues Interface.

## Summary
- Einfuehrung von `softplus_inv` und Erweiterung der Parameter-Spezifikation【F:03_baseline.R†L8-L35】.
- Blockweise Verarbeitung in `fit_joint_param` mit Initialisierung je Link-Funktion【F:03_baseline.R†L69-L118】.
- Tabellenfunktion verarbeitet Dimensionsvektoren korrekt【F:03_baseline.R†L121-L160】.
- Test `test_joint_mle.R` nutzt Rueckgabewert von `parse_param_spec`【F:tests/testthat/test_joint_mle.R†L9-L13】.

## Testing
- `bash run_checks.sh`【c4c249†L1-L23】