### PR TITLE
Fix Table Columns in run scripts

### DIFF
--- a/run3.R
+++ b/run3.R
@@ -61,8 +61,7 @@ tbl <- summary_table(
 tbl_out <- tbl[
 
   , c(
-    "dim", "distr", "ll_true_avg", "ll_joint_avg", "delta_joint",
-    "true_param1", "mean_param2", "mle_base1", "mle_base2"
+    "dim", "distr", "ll_true_avg", "ll_joint_avg", "delta_joint"
   )
 ]
 num_cols <- names(tbl_out)[sapply(tbl_out, is.numeric)]

--- a/run5.R
+++ b/run5.R
@@ -50,6 +50,9 @@ run_pipeline <- function(N_local = N, cfg = config, perm = NULL) {
   kernel_mismatch <<- sum(loglik_kernel) - target_ll
 
   eval_tab <- read.csv("results/evaluation_summary.csv")
+  eval_tab <- eval_tab[, !(names(eval_tab) %in%
+                             c("true_param1", "mean_param2",
+                               "mle_base1", "mle_base2"))]
   num_cols <- names(eval_tab)[sapply(eval_tab, is.numeric)]
   sum_row <- eval_tab[1, , drop = FALSE]
   for (col in names(sum_row)) {


### PR DESCRIPTION
## Summary
- strip unused columns from `tbl_out` in `run3.R`
- drop helper columns when loading `evaluation_summary.csv` in `run5.R`

## Testing
- `bash run_checks.sh` *(fails: subscript out of bounds in run5)*
- `bash lint.sh`