### PR TITLE
Fix run5 evaluation table output

### DIFF
--- a/05_joint_evaluation.R
+++ b/05_joint_evaluation.R
@@ -65,8 +65,7 @@ tbl_base$delta_ll_kernel <- tbl_base$ll_true_avg - tbl_base$ll_kernel_avg
 tbl_out <- tbl_base[
   , c(
     "dim", "distr", "ll_true_avg", "ll_joint_avg", "ll_trtf_avg",
-    "ll_kernel_avg", "delta_joint", "delta_ll_trtf", "delta_ll_kernel",
-    "true_param1", "mean_param2", "mle_base1", "mle_base2"
+    "ll_kernel_avg", "delta_joint", "delta_ll_trtf", "delta_ll_kernel"
   )
 ]
 num_cols <- names(tbl_out)[sapply(tbl_out, is.numeric)]

--- a/run5.R
+++ b/run5.R
@@ -25,7 +25,7 @@ run_pipeline <- function(N_local = N, cfg = config, perm = NULL) {
   X_pi_test  <<- data$test$sample$X_pi
   ll_test <<- data$test$df$ll_true
   N_test <<- nrow(X_pi_test)
-  
+
   if (!is.null(perm)) {
     X_pi_train <<- permute_data(X_pi_train, perm)
     X_pi_test  <<- permute_data(X_pi_test, perm)
@@ -34,21 +34,21 @@ run_pipeline <- function(N_local = N, cfg = config, perm = NULL) {
   param_res <- fit_joint_param(X_pi_train, X_pi_test, cfg)
   ll_delta_df_test <<- param_res$ll_delta_df_test
   true_ll_mat_test <<- param_res$true_ll_mat_test
-  
+
   source("04_forest_models.R")
   forest_res <- fit_forest(X_pi_train, X_pi_test)
   LD_hat <<- forest_res$LD_hat
-  
+
   source("06_kernel_smoothing.R")
   ks_model <- fit_kernel(as.data.frame(X_pi_train))
   KS_hat <<- predict(ks_model, newdata = as.data.frame(X_pi_test), type = "logdensity")
-  
+
   source("05_joint_evaluation.R", local = TRUE)
-  
+
   target_ll <- sum(ll_test)
   forest_mismatch <<- sum(loglik_trtf) - target_ll
   kernel_mismatch <<- sum(loglik_kernel) - target_ll
-  
+
   eval_tab <- read.csv("results/evaluation_summary.csv")
   eval_tab <- eval_tab[, !(names(eval_tab) %in%
                              c("true_param1", "mean_param2",


### PR DESCRIPTION
## Summary
- remove parameter-specific columns from evaluation table
- ensure run5 uses k1, k3, k2 ordering

## Testing
- `bash run_checks.sh`
- `Rscript run5.R`