### PR TITLE
Vergleichsfunktion für permutation

### DIFF
--- a/run5.R
+++ b/run5.R
@@ -15,7 +15,7 @@ source("03_baseline.R")
 
 permute_data <- function(mat, perm) mat[, perm, drop = FALSE]
 
-run_pipeline <- function(N_local = N, cfg = config, perm = NULL) {
+run_single <- function(N_local, cfg, perm = NULL) {
   Sys.setenv(N_total = N_local)
   set.seed(SEED)
   data <- generate_data(N_total = N_local, cfg = cfg)
@@ -73,12 +73,18 @@ run_pipeline <- function(N_local = N, cfg = config, perm = NULL) {
   if (file.exists(new_file)) file.remove(new_file)
   file.rename("results/evaluation_summary.csv", new_file)
   print(eval_tab)
+  eval_tab
+}
+
+run_pipeline <- function(N_local = N, cfg = config, perm = NULL) {
   if (is.null(perm)) {
-    eval_tab_nat <<- eval_tab
+    eval_tab_nat <<- run_single(N_local, cfg, NULL)
+    eval_tab <<- eval_tab_nat
   } else {
-    eval_tab_perm <<- eval_tab
+    eval_tab_nat <<- run_single(N_local, cfg, NULL)
+    eval_tab_perm <<- run_single(N_local, cfg, perm)
+    eval_tab <<- eval_tab_perm
   }
-  eval_tab <<- eval_tab
   source("dump_run5_code.R")
   invisible(eval_tab)
 }
@@ -94,6 +100,5 @@ run_joint_pipeline <- function(N_local = N) {
 }
 
 
-eval_tab_nat  <- run_pipeline(N)
-eval_tab_perm <- run_pipeline(N, perm = c(1, 3, 2))
+run_pipeline(N, perm = c(1, 3, 2))
 eval_tab <- eval_tab_nat


### PR DESCRIPTION
## Notes
- `run_pipeline` erstellt nun automatisch Vergleichstabellen in der natürlichen Reihenfolge und für eine angegebene Permutation.
- Dazu wurde die Kernlogik in `run_single` ausgelagert und die Skriptenden angepasst.

## Summary
- Neue Funktion `run_single` führt einen einzelnen Pipeline-Durchlauf aus
- `run_pipeline` ruft `run_single` für Basis- und Permutationsreihenfolge auf
- Skript führt jetzt nur noch einen Aufruf mit Permutation aus

## Testing
- `bash lint.sh`
- `bash run_checks.sh`