### PR TITLE
Remove joint likelihood evaluation

### DIFF
--- a/run3.R
+++ b/run3.R
@@ -54,14 +54,13 @@ tbl <- summary_table(
   X_pi_train,
   config,
   param_res,
-  param_res$ll_delta_df_test$ll_true,
-  param_res$ll_delta_df_test$ll_joint
+  param_res$ll_df_test$ll_true
 )
 
 tbl_out <- tbl[
 
   , c(
-    "dim", "distr", "ll_true_avg", "ll_joint_avg", "delta_joint"
+    "dim", "distr", "ll_true_avg", "mean_param1", "mean_param2"
   )
 ]
 num_cols <- names(tbl_out)[sapply(tbl_out, is.numeric)]
@@ -194,8 +193,7 @@ run_pipeline <- function(N_local = N) {
     data$train$sample$X_pi,
     config,
     param_res,
-    param_res$ll_delta_df_test$ll_true,
-    param_res$ll_delta_df_test$ll_joint
+    param_res$ll_df_test$ll_true
   )
   print(tbl)
   invisible(tbl)
@@ -206,8 +204,8 @@ run_joint_pipeline <- function(N_local = N) {
   data <- generate_data(N_total = N_local, cfg = config)
   joint_res <- fit_joint_param(data$train$sample$X_pi,
                                data$test$sample$X_pi, config)
-  print(joint_res$ll_delta_df_test)
-  invisible(joint_res$ll_delta_df_test)
+  print(joint_res$ll_df_test)
+  invisible(joint_res$ll_df_test)
 }
 
 if (sys.nframe() == 0) {

--- a/tests/testthat/test_fit_param.R
+++ b/tests/testthat/test_fit_param.R
@@ -12,9 +12,9 @@ data <- generate_data()
 X_pi_train <- data$train$sample$X_pi
 X_pi_test  <- data$test$sample$X_pi
 res <- fit_joint_param(X_pi_train, X_pi_test, config)
-mean_delta <- mean(abs(res$ll_delta_df_test$delta_joint))
+mean_ll <- mean(res$ll_df_test$ll_true)
 
-test_that("parametric fit delta_ll finite", {
-  expect_true(is.finite(mean_delta))
+test_that("parametric fit loglik finite", {
+  expect_true(is.finite(mean_ll))
 })
 


### PR DESCRIPTION
## Notes
- Entfernte die Berechnung der Log-Likelihood unter dem geschätzten Modell.
- `summary_table()` akzeptiert nun nur noch die wahre Log-Likelihood und liefert Mittelwerte der Parameter.
- `run3.R` zeigt jetzt nur noch die Spalten `dim`, `distr`, `ll_true_avg`, `mean_param1`, `mean_param2`.
- Test `test_fit_param.R` prüft die Finiteität der Log-Likelihood.

## Summary
- Bereinigung des Fit-Prozesses in `fit_joint_param`【F:03_baseline.R†L78-L108】.
- Anpassung von `summary_table()` auf reduzierte Ausgabe【F:03_baseline.R†L112-L149】.
- Aktualisierung der Pipeline in `run3.R`【F:run3.R†L52-L65】【F:run3.R†L188-L208】.
- Überarbeiteter Test auf endliche Log-Likelihood【F:tests/testthat/test_fit_param.R†L12-L19】.

## Testing
- `bash run_checks.sh`