### PR TITLE
Add setup_global function and initial test

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -1,0 +1,15 @@
+setup_global <- function(config, P_max) {
+  N <- 500
+  seed <- 42
+  split_ratio <- 0.70
+  H_grid <- seq.int(1L, as.integer(P_max))
+  model_ids <- c("TTM", "TRUE")
+  list(
+    N = N,
+    config = config,
+    seed = seed,
+    split_ratio = split_ratio,
+    H_grid = H_grid,
+    model_ids = model_ids
+  )
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+source("00_globals.R")
+
+test_dir("tests/testthat")

--- a/tests/testthat/test_globals.R
+++ b/tests/testthat/test_globals.R
@@ -1,0 +1,11 @@
+test_that("setup_global returns expected list", {
+  cfg <- list(a = 1, b = 2)
+  out <- setup_global(cfg, 4)
+  expect_type(out, "list")
+  expect_equal(out$N, 500)
+  expect_equal(out$config, cfg)
+  expect_equal(out$seed, 42)
+  expect_equal(out$split_ratio, 0.70)
+  expect_equal(out$H_grid, 1:4)
+  expect_equal(out$model_ids, c("TTM", "TRUE"))
+})


### PR DESCRIPTION
## Summary
- implement `setup_global` with fixed parameters
- add basic unit test verifying the returned structure

## Testing
- `Rscript tests/testthat.R`
- `Rscript -e 'lintr::lint_dir()'` *(fails: package not installed)*