### PR TITLE
Implementiere train_test_split und Tests

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -6,7 +6,7 @@ config <- list(
   list(distr = "norm", parm = NULL),
   list(distr = "exp",  parm = function(d) list(rate = d$X1)),
   list(distr = "beta", parm = function(d) list(shape1 = d$X2, shape2 = 1)),
-  list(distr = "gamma", parm = function(d) list(shape1 = d$X3, shape2 = 1))
+  list(distr = "gamma", parm = function(d) list(shape = d$X3, rate = 1))
 )
 
 #' Initialize global parameters

--- a/02_split.R
+++ b/02_split.R
@@ -1,0 +1,24 @@
+#' Train-test split for a data matrix
+#'
+#' Splits `X` into training and test sets based on `split_ratio`.
+#' A new random stream is used by adding one to `seed`.
+#'
+#' @param X Numeric matrix of observations
+#' @param split_ratio Proportion of rows assigned to the training set
+#' @param seed Integer random seed
+#' @return list with components `X_tr` and `X_te`
+#' @examples
+#' G <- setup_global()
+#' X <- gen_samples(G)
+#' S <- train_test_split(X, 0.7, 42)
+#' dim(S$X_tr)
+#' dim(S$X_te)
+train_test_split <- function(X, split_ratio, seed) {
+  N <- nrow(X)
+  set.seed(seed + 1)
+  idx <- sample.int(N, N)
+  N_tr <- floor(split_ratio * N)
+  X_tr <- X[idx[seq_len(N_tr)], , drop = FALSE]
+  X_te <- X[idx[(N_tr + 1):N], , drop = FALSE]
+  list(X_tr = X_tr, X_te = X_te)
+}

--- a/tests/testthat/test_data_generation.R
+++ b/tests/testthat/test_data_generation.R
@@ -1,4 +1,4 @@
-source("01_data_generation.R")
+source("../../01_data_generation.R")
 
 # Basic functionality of gen_samples
 

--- a/tests/testthat/test_split.R
+++ b/tests/testthat/test_split.R
@@ -1,0 +1,20 @@
+source("../../02_split.R")
+
+set.seed(1)
+X_dummy <- matrix(rnorm(100), nrow = 20)
+
+
+test_that("train_test_split returns proper dimensions", {
+  out <- train_test_split(X_dummy, 0.5, 123)
+  expect_equal(nrow(out$X_tr), floor(0.5 * nrow(X_dummy)))
+  expect_equal(nrow(out$X_te), nrow(X_dummy) - floor(0.5 * nrow(X_dummy)))
+  expect_equal(ncol(out$X_tr), ncol(X_dummy))
+  expect_equal(ncol(out$X_te), ncol(X_dummy))
+})
+
+test_that("train_test_split uses seed correctly", {
+  out1 <- train_test_split(X_dummy, 0.4, 42)
+  out2 <- train_test_split(X_dummy, 0.4, 42)
+  expect_equal(out1$X_tr, out2$X_tr)
+  expect_equal(out1$X_te, out2$X_te)
+})


### PR DESCRIPTION
## Notes
- `lintr` konnte nicht ausgeführt werden, da das Paket fehlt
- Tests schlagen aktuell fehl, siehe Log

## Summary
- neues Skript `02_split.R` definiert `train_test_split`
- Gamma-Parameter in `00_globals.R` korrigiert
- Testskripte an neue Pfade angepasst und neuen Test für `train_test_split` ergänzt