### PR TITLE
Automatischer Aufruf und Laden in 05_main

### DIFF
--- a/05_main.R
+++ b/05_main.R
@@ -8,6 +8,13 @@
 #' and the distribution configuration `config` without modifying
 #' `00_globals.R`.
 
+source("00_globals.R")
+source("01_data_generation.R")
+source("02_split.R")
+source("models/ttm_model.R")
+source("models/true_model.R")
+source("04_evaluation.R")
+
 N <- 500
 config <- list(
   list(distr = "norm", parm = NULL),
@@ -41,3 +48,7 @@ main <- function() {
 # - Quellcode in models/<neues>.R mit
 #     fit_<NAME>()  und  logL_<NAME>()
 # - anschließend hier laden und der Liste `models` hinzufügen.
+
+if (sys.nframe() == 0L) {
+  main()
+}


### PR DESCRIPTION
## Notes
- Fuege alle Abhaengigkeiten per `source()` ein und rufe `main()` automatisch auf.
- Ausgabe der Tests bleibt ohne Fehler.

## Summary
- Lade nun alle Hilfsfunktionen via `source` in `05_main.R` und rufe `main()` bei direktem Skriptaufruf auf.
- Beispielhafte Zeilen:
  - Einbindung der Skripte【F:05_main.R†L11-L16】
  - Automatischer Aufruf von `main()`【F:05_main.R†L52-L54】

## Testing
- `Rscript -e "lintr::lint('05_main.R')"` zeigte nur Warnungen zum sichtbaren Geltungsbereich【22839c†L1-L25】
- `Rscript tests/testthat.R` lief erfolgreich ohne Fehler【c3c399†L1-L12】
- Direkter Aufruf von `Rscript 05_main.R` erzeugt die erwartete Ergebnistabelle ohne NAs【0d6cae†L1-L10】