### PR TITLE
Implementiere Baseline-Tabelle in main

### DIFF
--- a/05_main.R
+++ b/05_main.R
@@ -36,8 +36,14 @@ main <- function() {
   M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)    # Script 5
   models <- setNames(list(M_TRUE), "TRUE")
   results <- evaluate_all(S$X_te, models)         # Script 6
-  print(results)
-  invisible(results)
+  baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
+  tab <- data.frame(
+    dim = seq_along(G$config),
+    distribution = sapply(G$config, `[[`, "distr"),
+    logL_baseline = baseline_ll
+  )
+  print(tab)
+  invisible(tab)
 }
 
 # einfache Möglichkeit, weitere Modelle anzuhängen:

--- a/models/true_model.R
+++ b/models/true_model.R
@@ -123,3 +123,28 @@ logL_TRUE <- function(M_TRUE, X) {
   if (!is.finite(val)) stop("log-likelihood not finite")
   val
 }
+
+#' Negative Log-Likelihood pro Dimension
+#'
+#' Berechnet f\u00fcr jedes Merkmal die durchschnittliche negative
+#' Log-Likelihood unter dem TRUE-Modell.
+#'
+#' @param M_TRUE Liste aus `fit_TRUE`
+#' @param X Matrix von Beobachtungen
+#' @return numerischer Vektor mit L\u00e4nge `K`
+#' @export
+logL_TRUE_dim <- function(M_TRUE, X) {
+  stopifnot(is.matrix(X))
+  theta_list <- M_TRUE$theta
+  config <- M_TRUE$config
+  K <- length(theta_list)
+  res <- numeric(K)
+  for (k in seq_len(K)) {
+    distr_k <- config[[k]]$distr
+    ll_k <- .log_density_vec(X[, k], distr_k, theta_list[[k]])
+    val <- -mean(ll_k)
+    if (!is.finite(val)) stop("log-likelihood not finite")
+    res[k] <- val
+  }
+  res
+}

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -1,0 +1,24 @@
+old_wd <- setwd("../..")
+source("05_main.R")
+
+set.seed(42)
+G <- list(N = 20, config = config, seed = 42, split_ratio = 0.7)
+
+expect_table <- data.frame(
+  dim = seq_along(G$config),
+  distribution = sapply(G$config, `[[`, "distr"),
+  logL_baseline = NA_real_
+)
+
+# run main with reduced N
+N <- 20
+res <- main()
+setwd(old_wd)
+
+test_that("main outputs baseline table", {
+  expect_s3_class(res, "data.frame")
+  expect_equal(colnames(res), c("dim", "distribution", "logL_baseline"))
+  expect_equal(res$dim, expect_table$dim)
+  expect_equal(res$distribution, expect_table$distribution)
+  expect_true(all(is.finite(res$logL_baseline)))
+})


### PR DESCRIPTION
## Summary
- erweitere TRUE-Modell um `logL_TRUE_dim`
- passe `main()` an und gebe Baseline-Tabelle aus
- erstelle Test `test_main.R` für neue Ausgabe

## Testing
- `Rscript tests/testthat.R`
- `Rscript -e 'lintr::lint_dir(".")'`

------
https://chatgpt.com/codex/tasks/task_e_683dd3ffd3248333a1abb8666bbf5379