### PR TITLE
Summenzeile in Ergebnistabelle

### DIFF
--- a/05_main.R
+++ b/05_main.R
@@ -38,10 +38,23 @@ main <- function() {
   results <- evaluate_all(S$X_te, models)         # Script 6
   baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
   tab <- data.frame(
-    dim = seq_along(G$config),
+    dim = as.character(seq_along(G$config)),
     distribution = sapply(G$config, `[[`, "distr"),
-    logL_baseline = baseline_ll
+    logL_baseline = baseline_ll,
+    stringsAsFactors = FALSE
   )
+
+  sum_row <- setNames(vector("list", ncol(tab)), names(tab))
+  for (nm in names(tab)) {
+    if (nm == "dim") {
+      sum_row[[nm]] <- "k"
+    } else if (is.numeric(tab[[nm]])) {
+      sum_row[[nm]] <- sum(tab[[nm]])
+    } else {
+      sum_row[[nm]] <- NA
+    }
+  }
+  tab <- rbind(tab, as.data.frame(sum_row, stringsAsFactors = FALSE))
   print(tab)
   invisible(tab)
 }

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -5,8 +5,8 @@ set.seed(42)
 G <- list(N = 20, config = config, seed = 42, split_ratio = 0.7)
 
 expect_table <- data.frame(
-  dim = seq_along(G$config),
-  distribution = sapply(G$config, `[[`, "distr"),
+  dim = c(as.character(seq_along(G$config)), "k"),
+  distribution = c(sapply(G$config, `[[`, "distr"), NA_character_),
   logL_baseline = NA_real_
 )
 
@@ -20,5 +20,9 @@ test_that("main outputs baseline table", {
   expect_equal(colnames(res), c("dim", "distribution", "logL_baseline"))
   expect_equal(res$dim, expect_table$dim)
   expect_equal(res$distribution, expect_table$distribution)
-  expect_true(all(is.finite(res$logL_baseline)))
+  expect_true(all(is.finite(res$logL_baseline[1:length(G$config)])))
+  expect_equal(
+    res$logL_baseline[length(G$config) + 1],
+    sum(res$logL_baseline[1:length(G$config)])
+  )
 })


### PR DESCRIPTION
## Zusammenfassung
- ergaenze in `main()` eine Summenzeile mit `k` und Spaltensummen
- passe Test `test_main.R` auf das neue Layout an

## Testing
- `Rscript -e "lintr::lint_dir()"`
- `Rscript tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_683fd8dbe02883339443d0b67d596e6d