### PR TITLE
Test für Baseline-Loglikelihood

### DIFF
--- a/tests/testthat/test_baseline_limit.R
+++ b/tests/testthat/test_baseline_limit.R
@@ -1,0 +1,11 @@
+old_wd <- setwd("../..")
+source("05_main.R")
+
+set.seed(123)
+N <- 10000
+full_res <- main()
+setwd(old_wd)
+
+test_that("logL_baseline within +/-10 for N=10000", {
+  expect_true(all(abs(full_res$logL_baseline) <= 10))
+})


### PR DESCRIPTION
## Zusammenfassung
- Test `baseline_limit` hinzugefügt
- prüft, dass für N=10000 die Beträge von `logL_baseline` kleiner 10 bleiben

## Testing
- `R -q -e "lintr::lint('tests/testthat/test_baseline_limit.R')"`
- `time R -q -f tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_683df2fef6988333a40b1c4b20019e40