### PR TITLE
Add TRTF results and adjust split

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -17,7 +17,7 @@ config <- list(
 setup_global <- function() {
   N <- 500
   seed <- 42
-  split_ratio <- 0.70
+  split_ratio <- 0.5
   P_max <- 6
   H_grid <- seq_len(P_max)
   model_ids <- c("TRUE")

--- a/05_main.R
+++ b/05_main.R
@@ -12,6 +12,7 @@ source("00_globals.R")
 source("01_data_generation.R")
 source("02_split.R")
 source("models/true_model.R")
+source("models/trtf_model.R")
 source("04_evaluation.R")
 
 N <- 100
@@ -28,19 +29,22 @@ main <- function() {
     N = N,
     config = config,
     seed = 42,
-    split_ratio = 0.70
+    split_ratio = 0.5
   )
 
   X <- gen_samples(G)                             # Script 2
   S <- train_test_split(X, G$split_ratio, G$seed) # Script 3
   M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)    # Script 5
-  models <- setNames(list(M_TRUE), "TRUE")
+  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)    # Script models/trtf_model.R
+  models <- setNames(list(M_TRUE, M_TRTF), c("TRUE", "TRTF"))
   results <- evaluate_all(S$X_te, models)         # Script 6
   baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
+  trtf_ll <- logL_TRTF_dim(M_TRTF, S$X_te)
   tab <- data.frame(
     dim = as.character(seq_along(G$config)),
     distribution = sapply(G$config, `[[`, "distr"),
     logL_baseline = baseline_ll,
+    logL_trtf = trtf_ll,
     stringsAsFactors = FALSE
   )
 

--- a/tests/testthat/test_globals.R
+++ b/tests/testthat/test_globals.R
@@ -4,7 +4,7 @@ test_that("setup_global returns expected list", {
   expect_equal(out$N, 500)
   expect_equal(out$config, config)
   expect_equal(out$seed, 42)
-  expect_equal(out$split_ratio, 0.70)
+  expect_equal(out$split_ratio, 0.5)
   expect_equal(out$P_max, 6)
   expect_equal(out$H_grid, seq_len(out$P_max))
   expect_equal(out$model_ids, "TRUE")

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -2,12 +2,13 @@ old_wd <- setwd("../..")
 source("05_main.R")
 
 set.seed(42)
-G <- list(N = 20, config = config, seed = 42, split_ratio = 0.7)
+G <- list(N = 20, config = config, seed = 42, split_ratio = 0.5)
 
 expect_table <- data.frame(
   dim = c(as.character(seq_along(G$config)), "k"),
   distribution = c(sapply(G$config, `[[`, "distr"), NA_character_),
-  logL_baseline = NA_real_
+  logL_baseline = NA_real_,
+  logL_trtf = NA_real_
 )
 
 # run main with reduced N
@@ -17,12 +18,16 @@ setwd(old_wd)
 
 test_that("main outputs baseline table", {
   expect_s3_class(res, "data.frame")
-  expect_equal(colnames(res), c("dim", "distribution", "logL_baseline"))
+  expect_equal(colnames(res), c("dim", "distribution", "logL_baseline", "logL_trtf"))
   expect_equal(res$dim, expect_table$dim)
   expect_equal(res$distribution, expect_table$distribution)
   expect_true(all(is.finite(res$logL_baseline[1:length(G$config)])))
   expect_equal(
     res$logL_baseline[length(G$config) + 1],
     sum(res$logL_baseline[1:length(G$config)])
+  )
+  expect_equal(
+    res$logL_trtf[length(G$config) + 1],
+    sum(res$logL_trtf[1:length(G$config)])
   )
 })


### PR DESCRIPTION
## Summary
- load `trtf_model` in orchestrator
- use 50/50 train/test split
- evaluate TRTF alongside baseline
- update globals and tests

## Testing
- `lintr::lint_dir()`
- `Rscript tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_683fee4121e4833382fd2284f41836ad