### PR TITLE
Add Kernel-Smoother model

### DIFF
--- a/05_main.R
+++ b/05_main.R
@@ -13,6 +13,7 @@ source("01_data_generation.R")
 source("02_split.R")
 source("models/true_model.R")
 source("models/trtf_model.R")
+source("models/ks_model.R")
 source("04_evaluation.R")
 
 N <- 100
@@ -36,15 +37,18 @@ main <- function() {
   S <- train_test_split(X, G$split_ratio, G$seed) # Script 3
   M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)    # Script 5
   M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)    # Script models/trtf_model.R
-  models <- setNames(list(M_TRUE, M_TRTF), c("TRUE", "TRTF"))
+  M_KS <- fit_KS(S$X_tr, S$X_te, G$config)        # Script models/ks_model.R
+  models <- setNames(list(M_TRUE, M_TRTF, M_KS), c("TRUE", "TRTF", "KS"))
   results <- evaluate_all(S$X_te, models)         # Script 6
   baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
   trtf_ll <- logL_TRTF_dim(M_TRTF, S$X_te)
+  ks_ll <- logL_KS_dim(M_KS, S$X_te)
   tab <- data.frame(
     dim = as.character(seq_along(G$config)),
     distribution = sapply(G$config, `[[`, "distr"),
     logL_baseline = baseline_ll,
     logL_trtf = trtf_ll,
+    logL_ks = ks_ll,
     stringsAsFactors = FALSE
   )
 

--- a/models/ks_model.R
+++ b/models/ks_model.R
@@ -1,0 +1,90 @@
+# Kernel Smoother Model basierend auf KDE
+# orientiert sich an Theory.md und trtf_logic.txt
+
+#' Fit KS model with simple Gaussian kernels
+#'
+#' @param X_tr Trainingsmatrix
+#' @param X_te Testmatrix
+#' @param config Liste der Verteilungsdefinitionen
+#' @param seed Zufallsstartwert
+#' @return Liste mit Elementen X_tr, h, config, logL_te
+#' @export
+fit_KS <- function(X_tr, X_te, config, seed = 42) {
+  stopifnot(is.matrix(X_tr), is.matrix(X_te))
+  set.seed(seed)
+  h <- apply(X_tr, 2, stats::bw.nrd0)
+  model <- list(X_tr = X_tr, h = h, config = config, seed = seed)
+  class(model) <- "ks_model"
+  model$logL_te <- logL_KS(model, X_te)
+  model
+}
+
+#' Berechne KDE Log-Dichten
+#'
+#' @param object ks_model
+#' @param newdata Matrix neuer Beobachtungen
+#' @param type "logdensity" oder "logdensity_by_dim"
+#' @return Matrix oder Vektor von Log-Dichten
+#' @export
+predict.ks_model <- function(object, newdata,
+                            type = c("logdensity", "logdensity_by_dim")) {
+  type <- match.arg(type)
+  X_tr <- object$X_tr
+  h <- object$h
+  stopifnot(is.matrix(newdata))
+  K <- ncol(X_tr)
+  n <- nrow(newdata)
+  ll <- matrix(NA_real_, nrow = n, ncol = K)
+  for (i in seq_len(n)) {
+    x <- newdata[i, ]
+    dens1 <- mean(dnorm((x[1] - X_tr[, 1]) / h[1]) / h[1])
+    ll[i, 1] <- log(dens1)
+    if (K > 1) {
+      for (k in 2:K) {
+        prod_num <- numeric(nrow(X_tr))
+        prod_den <- numeric(nrow(X_tr))
+        for (j in seq_len(nrow(X_tr))) {
+          num <- 1
+          den <- 1
+          for (r in seq_len(k)) {
+            num <- num * dnorm((x[r] - X_tr[j, r]) / h[r]) / h[r]
+            if (r < k) den <- den * dnorm((x[r] - X_tr[j, r]) / h[r]) / h[r]
+          }
+          prod_num[j] <- num
+          prod_den[j] <- den
+        }
+        g1k <- mean(prod_num)
+        g1km1 <- mean(prod_den)
+        f_k <- g1k / max(g1km1, .Machine$double.eps)
+        ll[i, k] <- log(f_k)
+      }
+    }
+  }
+  if (type == "logdensity_by_dim") return(ll)
+  rowSums(ll)
+}
+
+#' Negative Log-Likelihood Gesamt
+#'
+#' @param model ks_model
+#' @param X Matrix von Beobachtungen
+#' @return Skalar
+#' @export
+logL_KS <- function(model, X) {
+  val <- -mean(predict(model, X, type = "logdensity"))
+  if (!is.finite(val)) stop("log-likelihood not finite")
+  val
+}
+
+#' Negative Log-Likelihood je Dimension
+#'
+#' @param model ks_model
+#' @param X Matrix von Beobachtungen
+#' @return numerischer Vektor
+#' @export
+logL_KS_dim <- function(model, X) {
+  ll <- predict(model, X, type = "logdensity_by_dim")
+  res <- -colMeans(ll)
+  if (!all(is.finite(res))) stop("log-likelihood not finite")
+  res
+}

--- a/tests/testthat/test_ks_model.R
+++ b/tests/testthat/test_ks_model.R
@@ -1,0 +1,25 @@
+source("../../00_globals.R")
+source("../../01_data_generation.R")
+source("../../02_split.R")
+source("../../models/ks_model.R")
+
+set.seed(2)
+G <- setup_global()
+G$N <- 60
+X <- gen_samples(G)
+S <- train_test_split(X, G$split_ratio, G$seed)
+
+
+test_that("fit_KS liefert valides Objekt", {
+  mod <- fit_KS(S$X_tr, S$X_te, G$config)
+  expect_type(mod, "list")
+  expect_s3_class(mod, "ks_model")
+  expect_true(is.numeric(mod$logL_te))
+  expect_true(is.finite(mod$logL_te))
+})
+
+test_that("logL_KS gibt endlichen Wert", {
+  mod <- fit_KS(S$X_tr, S$X_te, G$config)
+  val <- logL_KS(mod, S$X_te)
+  expect_true(is.finite(val))
+})

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -8,7 +8,8 @@ expect_table <- data.frame(
   dim = c(as.character(seq_along(G$config)), "k"),
   distribution = c(sapply(G$config, `[[`, "distr"), NA_character_),
   logL_baseline = NA_real_,
-  logL_trtf = NA_real_
+  logL_trtf = NA_real_,
+  logL_ks = NA_real_
 )
 
 # run main with reduced N
@@ -18,7 +19,7 @@ setwd(old_wd)
 
 test_that("main outputs baseline table", {
   expect_s3_class(res, "data.frame")
-  expect_equal(colnames(res), c("dim", "distribution", "logL_baseline", "logL_trtf"))
+  expect_equal(colnames(res), c("dim", "distribution", "logL_baseline", "logL_trtf", "logL_ks"))
   expect_equal(res$dim, expect_table$dim)
   expect_equal(res$distribution, expect_table$distribution)
   expect_true(all(is.finite(res$logL_baseline[1:length(G$config)])))
@@ -29,5 +30,9 @@ test_that("main outputs baseline table", {
   expect_equal(
     res$logL_trtf[length(G$config) + 1],
     sum(res$logL_trtf[1:length(G$config)])
+  )
+  expect_equal(
+    res$logL_ks[length(G$config) + 1],
+    sum(res$logL_ks[1:length(G$config)])
   )
 })


### PR DESCRIPTION
## Summary
- implement Kernel Smoother KDE model
- integrate KS model in main workflow
- extend tests for new model and update expectations

## Testing
- `Rscript tests/testthat.R`
- `Rscript -e 'lintr::lint_dir(".")'`

------
https://chatgpt.com/codex/tasks/task_e_683ff521b8c08333a042a032c3bfa6f3