### PR TITLE
Verbessere ks_model

### DIFF
--- a/models/ks_model.R
+++ b/models/ks_model.R
@@ -1,6 +1,12 @@
 # Kernel Smoother Model basierend auf KDE
 # orientiert sich an Theory.md und trtf_logic.txt
 
+# interne Hilfsfunktion fuer log(sum(exp(x)))
+.log_sum_exp <- function(x) {
+  m <- max(x)
+  m + log(sum(exp(x - m)))
+}
+
 #' Fit KS model with simple Gaussian kernels
 #'
 #' @param X_tr Trainingsmatrix
@@ -37,27 +43,17 @@ predict.ks_model <- function(object, newdata,
   ll <- matrix(NA_real_, nrow = n, ncol = K)
   for (i in seq_len(n)) {
     x <- newdata[i, ]
-    dens1 <- mean(dnorm((x[1] - X_tr[, 1]) / h[1]) / h[1])
-    ll[i, 1] <- log(dens1)
+
+    logkern <- vapply(seq_len(K), function(r) {
+      dnorm((x[r] - X_tr[, r]) / h[r], log = TRUE) - log(h[r])
+    }, numeric(nrow(X_tr)))
+
+    cumsums <- t(apply(logkern, 1, cumsum))
+    log_g <- apply(cumsums, 2, function(v) .log_sum_exp(v) - log(nrow(X_tr)))
+
+    ll[i, 1] <- log_g[1]
     if (K > 1) {
-      for (k in 2:K) {
-        prod_num <- numeric(nrow(X_tr))
-        prod_den <- numeric(nrow(X_tr))
-        for (j in seq_len(nrow(X_tr))) {
-          num <- 1
-          den <- 1
-          for (r in seq_len(k)) {
-            num <- num * dnorm((x[r] - X_tr[j, r]) / h[r]) / h[r]
-            if (r < k) den <- den * dnorm((x[r] - X_tr[j, r]) / h[r]) / h[r]
-          }
-          prod_num[j] <- num
-          prod_den[j] <- den
-        }
-        g1k <- mean(prod_num)
-        g1km1 <- mean(prod_den)
-        f_k <- g1k / max(g1km1, .Machine$double.eps)
-        ll[i, k] <- log(f_k)
-      }
+      ll[i, 2:K] <- diff(log_g)
     }
   }
   if (type == "logdensity_by_dim") return(ll)


### PR DESCRIPTION
## Summary
- berechne log-Summen mit `.log_sum_exp`
- vektorisiere Berechnung der log-Dichten im `ks_model`

## Testing
- `Rscript tests/testthat.R`
- `Rscript -e 'lintr::lint_dir()'`

------
https://chatgpt.com/codex/tasks/task_e_683ff9f1d4b08333b9d69ead05ca7fa6