### PR TITLE
Entferne params_k aus Sample-Generierung

### DIFF
--- a/01_data_generation.R
+++ b/01_data_generation.R
@@ -15,7 +15,7 @@ Generate_iid_from_config <- function(N , cfg){
     for (k in seq_len(K)) {
       c_k <- cfg[[k]]
       if (is.null(c_k$parm)) {
-        params_k <- list()
+        args <- list()
       } else {
         if (k == 1) {
           prev <- data.frame()
@@ -23,17 +23,17 @@ Generate_iid_from_config <- function(N , cfg){
           prev <- as.data.frame(as.list(X[i, seq_len(k - 1)]))
           names(prev) <- paste0("X", seq_len(k - 1))
         }
-        params_k <- c_k$parm(prev)
+        args <- c_k$parm(prev)
       }
       fun <- get(paste0("r", c_k$distr), mode = "function")
       if (c_k$distr == "gamma" &&
-          all(c("shape1", "shape2") %in% names(params_k))) {
-        params_k <- list(shape = params_k$shape1, scale = params_k$shape2)
+          all(c("shape1", "shape2") %in% names(args))) {
+        args <- list(shape = args$shape1, scale = args$shape2)
       }
-      params_k <- lapply(params_k, function(p) {
+      args <- lapply(args, function(p) {
         if (!is.finite(p) || p <= 0) 1e-3 else p
       })
-      X[i, k] <- do.call(fun, c(list(n = 1L), params_k))
+      X[i, k] <- do.call(fun, c(list(n = 1L), args))
     }
   }
   colnames(X) <- paste0("X", seq_len(K))

--- a/roadmap.md
+++ b/roadmap.md
@@ -42,18 +42,18 @@ FUNCTION gen_samples(G):
     3  INIT X ← matrix(NA, N, K)
     4  FOR i = 1,…,N:
     5      FOR k = 1,…,K:                        # sequentiell ⇒ bedingt
-    6          c_k      ← config[k]
-    7          params_k ←
+    6          c_k   ← config[k]
+    7          args  ←
                  IF is.null(c_k.parm)
                  THEN {}
                  ELSE c_k.parm( X[i, 1:(k−1)] )
-    8          IF c_k.distr = "gamma" ∧ {shape1, shape2} ⊂ names(params_k):
-                 params_k ← {shape = params_k.shape1,
-                              scale = params_k.shape2}
-    9          FOR p ∈ params_k:
+    8          IF c_k.distr = "gamma" ∧ {shape1, shape2} ⊂ names(args):
+                 args ← {shape = args.shape1,
+                          scale = args.shape2}
+    9          FOR p ∈ args:
                  IF ¬finite(p) ∨ p ≤ 0: p ← 1e−3
    10          fun ← get("r" ++ c_k.distr)
-   11          X[i,k]  ← fun(1, params_k)
+   11          X[i,k]  ← fun(1, args)
    12  SET colnames(X) ← {"X1",…,"XK"}
    13  RETURN X
 ```


### PR DESCRIPTION
## Zusammenfassung
- ersetze Variable `params_k` in `Generate_iid_from_config` durch `args`
- passe Pseudocode in `roadmap.md` an

## Tests
- `R -q -e "lintr::lint_dir()"`
- `R -q -f tests/testthat.R`


------
https://chatgpt.com/codex/tasks/task_e_683ffdcac5f08333b2b132d2cbb73faa