### PR TITLE
Add Triangular Transport Map model

### DIFF
--- a/models/triangular_transport_map.R
+++ b/models/triangular_transport_map.R
@@ -1,0 +1,112 @@
+# Triangular Transport Map using linear shift and scale
+# relies on helper functions from 01_data_generation.R
+
+#' Fit linear triangular transport map
+#'
+#' @param X_tr training matrix
+#' @param X_te test matrix
+#' @return list representing the fitted model
+#' @export
+fit_TTM <- function(X_tr, X_te) {
+  stopifnot(is.matrix(X_tr), is.matrix(X_te))
+  mu <- colMeans(X_tr)
+  names(mu) <- colnames(X_tr)
+  Sigma <- stats::cov(X_tr)
+  L <- t(chol(Sigma))
+  L_inv <- solve(L)
+  model <- list(mu = mu, L = L, L_inv = L_inv)
+  class(model) <- "ttm"
+  model$logL_te <- logL_TTM(model, X_te)
+  model
+}
+
+#' Predict log-densities for new observations
+#'
+#' @param object ttm model
+#' @param newdata matrix of observations
+#' @param type "logdensity" or "logdensity_by_dim"
+#' @return numeric vector or matrix of log-densities
+#' @export
+predict.ttm <- function(object, newdata,
+                        type = c("logdensity", "logdensity_by_dim")) {
+  type <- match.arg(type)
+  stopifnot(is.matrix(newdata))
+  Z <- t(apply(newdata, 1L, S_forward, θ = object))
+  ld_norm <- dnorm(Z, log = TRUE)
+  log_diag <- log(diag(object$L_inv))
+  if (type == "logdensity_by_dim") {
+    res <- t(t(ld_norm) + log_diag)
+    return(res)
+  }
+  log_det <- sum(log_diag)
+  rowSums(ld_norm) + log_det
+}
+
+#' Compute mean negative log-likelihood
+#'
+#' @param model ttm model
+#' @param X matrix of observations
+#' @return scalar
+#' @export
+logL_TTM <- function(model, X) {
+  ll <- predict(model, X, type = "logdensity")
+  val <- -mean(ll)
+  if (!is.finite(val)) stop("log-likelihood not finite")
+  val
+}
+
+#' Negative log-likelihood by dimension
+#'
+#' @param model ttm model
+#' @param X matrix of observations
+#' @return numeric vector
+#' @export
+logL_TTM_dim <- function(model, X) {
+  ll <- predict(model, X, type = "logdensity_by_dim")
+  res <- -colMeans(ll)
+  if (!all(is.finite(res))) stop("log-likelihood not finite")
+  res
+}
+
+#' Conditional sampling from the fitted model
+#'
+#' @param model ttm model
+#' @param b_fix named numeric vector of fixed coordinates
+#' @param m number of samples
+#' @return matrix of samples of size m x K
+#' @export
+
+#' Conditional sampling from the fitted model
+#'
+#' @param model ttm model
+#' @param b_fix named numeric vector of fixed coordinates
+#' @param m number of samples
+#' @return matrix of samples of size m x K
+#' @export
+sample_TTM <- function(model, b_fix, m = 1L) {
+  stopifnot(is.numeric(b_fix), is.numeric(m), m > 0)
+  if (is.null(names(b_fix))) {
+    fix_idx <- seq_along(b_fix)
+  } else {
+    fix_idx <- match(names(b_fix), names(model$mu))
+  }
+  mu <- model$mu
+  L <- model$L
+  Sigma <- L %*% t(L)
+  A <- setdiff(seq_along(mu), fix_idx)
+  Sigma_BB <- Sigma[fix_idx, fix_idx, drop = FALSE]
+  Sigma_AB <- Sigma[A, fix_idx, drop = FALSE]
+  Sigma_AA <- Sigma[A, A, drop = FALSE]
+  mu_B <- mu[fix_idx]
+  mu_A <- mu[A]
+  cond_mean <- c(mu_A + Sigma_AB %*% solve(Sigma_BB) %*% (as.numeric(b_fix) - mu_B))
+  cond_cov <- Sigma_AA - Sigma_AB %*% solve(Sigma_BB) %*% t(Sigma_AB)
+  cond_cov <- cond_cov + diag(1e-6, nrow(cond_cov))
+  Z <- MASS::mvrnorm(n = m, mu = cond_mean, Sigma = cond_cov)
+  if (m == 1) Z <- matrix(Z, nrow = 1)
+  out <- matrix(NA_real_, nrow = m, ncol = length(mu))
+  out[, fix_idx] <- matrix(rep(as.numeric(b_fix), each = m), nrow = m)
+  out[, A] <- Z
+  colnames(out) <- names(mu)
+  out
+}

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -9,6 +9,7 @@ expect_table <- data.frame(
   distribution = c(sapply(G$config, `[[`, "distr"), NA_character_),
   logL_baseline = NA_real_,
   logL_trtf = NA_real_,
+  logL_ttm = NA_real_,
   logL_ks = NA_real_
 )
 
@@ -23,7 +24,7 @@ test_that("main outputs tables for both orders", {
 
   for (tab in res) {
     expect_s3_class(tab, "data.frame")
-    expect_equal(colnames(tab), c("dim", "distribution", "logL_baseline", "logL_trtf", "logL_ks"))
+    expect_equal(colnames(tab), c("dim", "distribution", "logL_baseline", "logL_trtf", "logL_ttm", "logL_ks"))
     expect_equal(tab$dim, expect_table$dim)
     expect_equal(tab$distribution, expect_table$distribution)
     expect_true(all(is.finite(tab$logL_baseline[1:length(G$config)])))
@@ -34,6 +35,10 @@ test_that("main outputs tables for both orders", {
     expect_equal(
       tab$logL_trtf[length(G$config) + 1],
       sum(tab$logL_trtf[1:length(G$config)])
+    )
+    expect_equal(
+      tab$logL_ttm[length(G$config) + 1],
+      sum(tab$logL_ttm[1:length(G$config)])
     )
     expect_equal(
       tab$logL_ks[length(G$config) + 1],

--- a/tests/testthat/test_ttm.R
+++ b/tests/testthat/test_ttm.R
@@ -1,0 +1,27 @@
+source("../../00_globals.R")
+source("../../01_data_generation.R")
+source("../../02_split.R")
+source("../../models/triangular_transport_map.R")
+
+set.seed(1)
+G <- setup_global()
+G$N <- 60
+X <- gen_samples(G)
+S <- train_test_split(X, G$split_ratio, G$seed)
+
+
+test_that("fit_TTM liefert valides Modell", {
+  mod <- fit_TTM(S$X_tr, S$X_te)
+  expect_type(mod, "list")
+  expect_s3_class(mod, "ttm")
+  expect_true(is.numeric(mod$logL_te))
+  expect_true(is.finite(mod$logL_te))
+  expect_equal(length(mod$mu), ncol(S$X_tr))
+})
+
+
+test_that("logL_TTM berechnet endlichen Wert", {
+  mod <- fit_TTM(S$X_tr, S$X_te)
+  val <- logL_TTM(mod, S$X_te)
+  expect_true(is.finite(val))
+})


### PR DESCRIPTION
## Summary
- implement `triangular_transport_map` with fit, predict, log-likelihood and sampling
- integrate TTM model into main workflow
- adjust main tests for new column
- provide basic unit tests for TTM

## Testing
- `lintr::lint_dir()`
- `testthat::test_dir('tests/testthat', reporter='summary')`


------
https://chatgpt.com/codex/tasks/task_e_68403e27cb208333abaf76558e924ea3