### PR TITLE
Implement Triangular Transport Map model

### DIFF
--- a/05_main.R
+++ b/05_main.R
@@ -14,6 +14,7 @@ source("02_split.R")
 source("models/true_model.R")
 source("models/trtf_model.R")
 source("models/ks_model.R")
+source("models/ttm_model.R")
 source("04_evaluation.R")
 
 round_df <- function(df, digits = 3) {
@@ -47,10 +48,12 @@ main <- function() {
   M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)    # Script 5
   M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)    # Script models/trtf_model.R
   M_KS   <- fit_KS(S$X_tr, S$X_te, G$config)      # Script models/ks_model.R
+  M_TTM  <- fit_TTM(S$X_tr, S$X_te)               # Script models/ttm_model.R
 
   baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
   trtf_ll     <- logL_TRTF_dim(M_TRTF, S$X_te)
   ks_ll       <- logL_KS_dim(M_KS, S$X_te)
+  ttm_ll      <- logL_TTM_dim(M_TTM, S$X_te)
 
   tab_normal <- data.frame(
     dim = as.character(seq_along(G$config)),
@@ -58,6 +61,7 @@ main <- function() {
     logL_baseline = baseline_ll,
     logL_trtf = trtf_ll,
     logL_ks = ks_ll,
+    logL_ttm = ttm_ll,
     stringsAsFactors = FALSE
   )
 
@@ -82,10 +86,12 @@ main <- function() {
   M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
   M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
   M_KS_p   <- fit_KS(X_tr_p, X_te_p, G$config)
+  M_TTM_p  <- fit_TTM(X_tr_p, X_te_p)
 
   baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
   trtf_ll_p     <- logL_TRTF_dim(M_TRTF_p, X_te_p)
   ks_ll_p       <- logL_KS_dim(M_KS_p, X_te_p)
+  ttm_ll_p      <- logL_TTM_dim(M_TTM_p, X_te_p)
 
   tab_perm <- data.frame(
     dim = as.character(seq_along(G$config)),
@@ -93,6 +99,7 @@ main <- function() {
     logL_baseline = baseline_ll_p,
     logL_trtf = trtf_ll_p,
     logL_ks = ks_ll_p,
+    logL_ttm = ttm_ll_p,
     stringsAsFactors = FALSE
   )
 
@@ -114,6 +121,7 @@ main <- function() {
   }, numeric(nrow(S$X_te))))
   ld_trtf <- as.numeric(predict(M_TRTF, S$X_te, type = "logdensity"))
   ld_ks   <- as.numeric(predict(M_KS, S$X_te, type = "logdensity"))
+  ld_ttm  <- as.numeric(predict(M_TTM, S$X_te, type = "logdensity"))
 
   plot(ld_base, ld_base, pch = 16, col = "black",
        xlab = "True log-Dichte",
@@ -122,8 +130,8 @@ main <- function() {
   points(ld_base, ld_trtf, col = "blue", pch = 1)
   points(ld_base, ld_ks,   col = "red",  pch = 2)
   abline(a = 0, b = 1)
-  legend("topleft", legend = c("true_baseline", "trtf", "ks"),
-         col = c("black", "blue", "red"), pch = c(16, 1, 2))
+  legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
+         col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
 
   ## Log-Dichten fuer Plot (Permutation)
   ld_base_p <- rowSums(vapply(seq_along(G$config), function(k) {
@@ -131,6 +139,7 @@ main <- function() {
   }, numeric(nrow(X_te_p))))
   ld_trtf_p <- as.numeric(predict(M_TRTF_p, X_te_p, type = "logdensity"))
   ld_ks_p   <- as.numeric(predict(M_KS_p,   X_te_p, type = "logdensity"))
+  ld_ttm_p  <- as.numeric(predict(M_TTM_p,  X_te_p, type = "logdensity"))
 
   plot(ld_base_p, ld_base_p, pch = 16, col = "black",
        xlab = "True log-Dichte",
@@ -139,8 +148,8 @@ main <- function() {
   points(ld_base_p, ld_trtf_p, col = "blue", pch = 1)
   points(ld_base_p, ld_ks_p,   col = "red",  pch = 2)
   abline(a = 0, b = 1)
-  legend("topleft", legend = c("true_baseline", "trtf", "ks"),
-         col = c("black", "blue", "red"), pch = c(16, 1, 2))
+  legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
+         col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
 
   print(round_df(tab_normal, digits = 3))
   print(round_df(tab_perm, digits = 3))

--- a/models/ttm_model.R
+++ b/models/ttm_model.R
@@ -1,0 +1,216 @@
+# Triangular Transport Map (shift-scale version)
+# Follows notation in README.md and Theory.md.
+
+# create initial parameter container
+.make_theta <- function(K) {
+  par_env <- new.env(parent = emptyenv())
+  par_env$par_m <- lapply(seq_len(K), function(k) rep(0, k))
+  par_env$par_s <- lapply(seq_len(K), function(k) rep(0, k))
+
+  m_list <- lapply(seq_len(K), function(k) {
+    force(k)
+    function(x) {
+      x_in <- if (k == 1) numeric(0) else x[seq_len(k - 1)]
+      as.numeric(c(1, x_in) %*% par_env$par_m[[k]])
+    }
+  })
+
+  s_list <- lapply(seq_len(K), function(k) {
+    force(k)
+    function(x) {
+      x_in <- if (k == 1) numeric(0) else x[seq_len(k - 1)]
+      exp(as.numeric(c(1, x_in) %*% par_env$par_s[[k]]))
+    }
+  })
+
+  list(env = par_env, m = m_list, s = s_list)
+}
+
+# Sequential forward map S
+S_forward <- function(x, theta) {
+  K <- length(theta$m)
+  z <- numeric(K)
+  for (k in seq_len(K)) {
+    m_k <- theta$m[[k]](x)
+    s_k <- theta$s[[k]](x)
+    z[k] <- (x[k] - m_k) / s_k
+  }
+  z
+}
+
+# Inverse map R
+R_inverse <- function(z, theta) {
+  K <- length(theta$m)
+  x <- numeric(K)
+  for (k in seq_len(K)) {
+    m_k <- theta$m[[k]](x)
+    s_k <- theta$s[[k]](x)
+    x[k] <- m_k + s_k * z[k]
+  }
+  x
+}
+
+# Jacobian diagonal entries 1 / s_k
+Jacobian_Diagonal <- function(x, theta) {
+  K <- length(theta$s)
+  res <- numeric(K)
+  for (k in seq_len(K)) {
+    res[k] <- 1 / theta$s[[k]](x)
+  }
+  res
+}
+
+# Log determinant of Jacobian
+LogDet_Jacobian <- function(x, theta) {
+  -sum(log(vapply(seq_along(theta$s), function(k) theta$s[[k]](x), numeric(1))))
+}
+
+# Objective J_N as mean negative log-likelihood
+Objective_J_N <- function(theta, X) {
+  stopifnot(is.matrix(X))
+  n <- nrow(X)
+  vals <- apply(X, 1L, function(x) {
+    z <- S_forward(x, theta)
+    logphi <- sum(dnorm(z, log = TRUE))
+    logdet <- LogDet_Jacobian(x, theta)
+    -(logphi + logdet)
+  })
+  mean(vals)
+}
+
+# Fit TTM via simple SGD
+fit_TTM <- function(X_tr, X_te, config = NULL, lr = 1e-2, epochs = 200,
+                    patience = 10, seed = 42) {
+  stopifnot(is.matrix(X_tr), is.matrix(X_te))
+  set.seed(seed)
+  K <- ncol(X_tr)
+  theta <- .make_theta(K)
+
+  n <- nrow(X_tr)
+  idx <- sample.int(n)
+  n_val <- floor(0.2 * n)
+  val_idx <- idx[seq_len(n_val)]
+  tr_idx <- idx[-seq_len(n_val)]
+
+  best_val <- Inf
+  best_par_m <- theta$env$par_m
+  best_par_s <- theta$env$par_s
+  stale <- 0
+
+  x_with_intercept <- lapply(seq_len(K), function(k) {
+    if (k == 1) {
+      matrix(1, nrow = length(tr_idx), ncol = 1)
+    } else {
+      cbind(1, X_tr[tr_idx, seq_len(k - 1), drop = FALSE])
+    }
+  })
+
+  x_with_intercept_val <- lapply(seq_len(K), function(k) {
+    if (k == 1) {
+      matrix(1, nrow = length(val_idx), ncol = 1)
+    } else {
+      cbind(1, X_tr[val_idx, seq_len(k - 1), drop = FALSE])
+    }
+  })
+
+  for (epoch in seq_len(epochs)) {
+    grad_m <- lapply(seq_len(K), function(k) rep(0, k))
+    grad_s <- lapply(seq_len(K), function(k) rep(0, k))
+
+    for (i in seq_along(tr_idx)) {
+      x <- X_tr[tr_idx[i], ]
+      for (k in seq_len(K)) {
+        x_par <- x_with_intercept[[k]][i, ]
+        m_k <- as.numeric(x_par %*% theta$env$par_m[[k]])
+        log_s_k <- as.numeric(x_par %*% theta$env$par_s[[k]])
+        s_k <- exp(log_s_k)
+        z_k <- (x[k] - m_k) / s_k
+        grad_m[[k]] <- grad_m[[k]] - (z_k / s_k) * x_par
+        grad_s[[k]] <- grad_s[[k]] + (1 - z_k^2) * x_par
+      }
+    }
+
+    for (k in seq_len(K)) {
+      theta$env$par_m[[k]] <- theta$env$par_m[[k]] - lr * grad_m[[k]] / length(tr_idx)
+      theta$env$par_s[[k]] <- theta$env$par_s[[k]] - lr * grad_s[[k]] / length(tr_idx)
+    }
+
+    val_loss <- Objective_J_N(theta, X_tr[val_idx, , drop = FALSE])
+    if (val_loss < best_val - 1e-4) {
+      best_val <- val_loss
+      best_par_m <- lapply(theta$env$par_m, identity)
+      best_par_s <- lapply(theta$env$par_s, identity)
+      stale <- 0
+    } else {
+      stale <- stale + 1
+      if (stale >= patience) break
+    }
+  }
+
+  theta$env$par_m <- best_par_m
+  theta$env$par_s <- best_par_s
+
+  model <- list(theta = theta, config = config,
+                train_logL = -Objective_J_N(theta, X_tr[tr_idx, , drop = FALSE]),
+                test_logL = -Objective_J_N(theta, X_te))
+  class(model) <- "ttm"
+  model
+}
+
+# prediction
+predict.ttm <- function(object, newdata,
+                        type = c("logdensity", "logdensity_by_dim")) {
+  type <- match.arg(type)
+  stopifnot(is.matrix(newdata))
+  K <- length(object$theta$m)
+  n <- nrow(newdata)
+  ll <- matrix(NA_real_, nrow = n, ncol = K)
+  for (i in seq_len(n)) {
+    x <- newdata[i, ]
+    for (k in seq_len(K)) {
+      m_k <- object$theta$m[[k]](x)
+      s_k <- object$theta$s[[k]](x)
+      z_k <- (x[k] - m_k) / s_k
+      ll[i, k] <- dnorm(z_k, log = TRUE) - log(s_k)
+    }
+  }
+  if (type == "logdensity_by_dim") return(ll)
+  rowSums(ll)
+}
+
+# log-likelihood helpers
+logL_TTM <- function(model, X) {
+  val <- -mean(predict(model, X, type = "logdensity"))
+  if (!is.finite(val)) stop("log-likelihood not finite")
+  val
+}
+
+logL_TTM_dim <- function(model, X) {
+  ll <- predict(model, X, type = "logdensity_by_dim")
+  res <- -colMeans(ll)
+  if (!all(is.finite(res))) stop("log-likelihood not finite")
+  res
+}
+
+# Optional conditional sampler
+Conditional_Sample_TTM <- function(fix_idx, fix_val, theta_hat, m = 1L) {
+  K <- length(theta_hat$m)
+  stopifnot(all(fix_idx %in% seq_len(K)))
+  z <- matrix(rnorm(m * K), nrow = m)
+  x <- matrix(NA_real_, nrow = m, ncol = K)
+  for (j in seq_len(m)) {
+    for (k in seq_len(K)) {
+      if (k %in% fix_idx) {
+        x[j, k] <- fix_val[which(fix_idx == k)]
+      } else {
+        parents <- if (k == 1) numeric(0) else x[j, seq_len(k - 1)]
+        m_k <- theta_hat$m[[k]](parents)
+        s_k <- theta_hat$s[[k]](parents)
+        x[j, k] <- m_k + s_k * z[j, k]
+      }
+    }
+  }
+  colnames(x) <- paste0("X", seq_len(K))
+  x
+}
+

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -9,7 +9,8 @@ expect_table <- data.frame(
   distribution = c(sapply(G$config, `[[`, "distr"), NA_character_),
   logL_baseline = NA_real_,
   logL_trtf = NA_real_,
-  logL_ks = NA_real_
+  logL_ks = NA_real_,
+  logL_ttm = NA_real_
 )
 
 # run main with reduced N
@@ -23,7 +24,7 @@ test_that("main outputs tables for both orders", {
 
   for (tab in res) {
     expect_s3_class(tab, "data.frame")
-    expect_equal(colnames(tab), c("dim", "distribution", "logL_baseline", "logL_trtf", "logL_ks"))
+    expect_equal(colnames(tab), c("dim", "distribution", "logL_baseline", "logL_trtf", "logL_ks", "logL_ttm"))
     expect_equal(tab$dim, expect_table$dim)
     expect_equal(tab$distribution, expect_table$distribution)
     expect_true(all(is.finite(tab$logL_baseline[1:length(G$config)])))
@@ -35,9 +36,13 @@ test_that("main outputs tables for both orders", {
       tab$logL_trtf[length(G$config) + 1],
       sum(tab$logL_trtf[1:length(G$config)])
     )
-    expect_equal(
-      tab$logL_ks[length(G$config) + 1],
-      sum(tab$logL_ks[1:length(G$config)])
-    )
-  }
-})
+      expect_equal(
+        tab$logL_ks[length(G$config) + 1],
+        sum(tab$logL_ks[1:length(G$config)])
+      )
+      expect_equal(
+        tab$logL_ttm[length(G$config) + 1],
+        sum(tab$logL_ttm[1:length(G$config)])
+      )
+    }
+  })

--- a/tests/testthat/test_ttm_model.R
+++ b/tests/testthat/test_ttm_model.R
@@ -13,8 +13,8 @@ S <- train_test_split(X, G$split_ratio, G$seed)
 test_that("fit_TTM liefert valides Objekt", {
   mod <- fit_TTM(S$X_tr, S$X_te)
   expect_type(mod, "list")
-  expect_true(is.numeric(mod$logL_te))
-  expect_true(is.finite(mod$logL_te))
+  expect_true(is.numeric(mod$test_logL))
+  expect_true(is.finite(mod$test_logL))
 })
 
 


### PR DESCRIPTION
## Summary
- add shift-scale Triangular Transport Map implementation
- extend main experiment to evaluate the TTM model
- update unit tests for new output columns

## Testing
- `Rscript tests/testthat.R`
- `Rscript -e "lintr::lint_dir('.')"` (with warnings)

------
https://chatgpt.com/codex/tasks/task_e_68413773d810833399224a56ca2dda75