### PR TITLE
Rename main script and integrate EDA PDF creation

### DIFF
--- a/EDA.R
+++ b/EDA.R
@@ -49,7 +49,8 @@ compute_param_values <- function(X, cfg) {
   params
 }
 
-create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf") {
+create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
+                              scatter_data = NULL) {
   params <- compute_param_values(X, cfg)
   pdf(output_file)
   for (k in seq_along(params)) {
@@ -74,6 +75,33 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf") {
                                  sprintf("high %0.2f", max(color_val))),
            fill = cols[c(1, 100)], bty = "n", title = param_name)
   }
+
+  if (!is.null(scatter_data)) {
+    with(scatter_data, {
+      plot(ld_base, ld_base, pch = 16, col = "black",
+           xlab = "True log-Dichte",
+           ylab = "Geschaetzte log-Dichte",
+           main = "Originalreihenfolge")
+      points(ld_base, ld_trtf, col = "blue", pch = 1)
+      points(ld_base, ld_ks,   col = "red",  pch = 2)
+      points(ld_base, ld_ttm,  col = "darkgreen", pch = 3)
+      abline(a = 0, b = 1)
+      legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
+             col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
+
+      plot(ld_base_p, ld_base_p, pch = 16, col = "black",
+           xlab = "True log-Dichte",
+           ylab = "Geschaetzte log-Dichte",
+           main = "Permutation")
+      points(ld_base_p, ld_trtf_p, col = "blue", pch = 1)
+      points(ld_base_p, ld_ks_p,   col = "red",  pch = 2)
+      points(ld_base_p, ld_ttm_p,  col = "darkgreen", pch = 3)
+      abline(a = 0, b = 1)
+      legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
+             col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
+    })
+  }
+
   dev.off()
   invisible(output_file)
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Ablaufdiagramm der Skripte und Modelle
 
 Das folgende Mermaid-Diagramm veranschaulicht die Interaktion der Skripte
-`01_data_generation.R`, `02_split.R`, `04_evaluation.R` und `05_main.R` sowie der
+`01_data_generation.R`, `02_split.R`, `04_evaluation.R` und `main.R` sowie der
 vier Modellimplementierungen **TRTF**, **TrueModel**, **KS-Modell** und
 **TTM-Modell**. Alle Berechnungen der Log-Likelihood finden konsequent im
 Log-Raum statt, wie in `README.md` beschrieben. Parameter, die strikt positiv
@@ -47,7 +47,7 @@ graph TD
         G1["evaluate_all(X_te, model_list)"] -->|"ruft logL_<id> auf"| G2["Tabelle"]
     end
 
-    subgraph Script05["05_main.R"]
+    subgraph Script05["main.R"]
         H1["main()"] -->|"erstellt G"| Gsetup["G = list(N, config, seed, split_ratio)"]
         H1 -->|"ruft"| A1
         H1 -->|"ruft"| B1

--- a/main.R
+++ b/main.R
@@ -114,18 +114,6 @@ main <- function() {
   ld_ks   <- as.numeric(predict(M_KS, S$X_te, type = "logdensity"))
   ld_ttm  <- as.numeric(predict(M_TTM, S$X_te, type = "logdensity"))
 
-  plot(ld_base, ld_base, pch = 16, col = "black",
-       xlab = "True log-Dichte",
-       ylab = "Geschaetzte log-Dichte",
-       main = "Originalreihenfolge")
-  points(ld_base, ld_trtf, col = "blue", pch = 1)
-  points(ld_base, ld_ks,   col = "red",  pch = 2)
-  points(ld_base, ld_ttm,  col = "darkgreen", pch = 3)
-  abline(a = 0, b = 1)
-  legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
-         col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
-  create_EDA_report(S$X_tr, G$config)
-
   ## Log-Dichten fuer Plot (Permutation)
   ld_base_p <- rowSums(vapply(seq_along(G$config), function(k) {
     .log_density_vec(X_te_p[, k], G$config[[k]]$distr, M_TRUE_p$theta[[k]])
@@ -134,16 +122,18 @@ main <- function() {
   ld_ks_p   <- as.numeric(predict(M_KS_p,   X_te_p, type = "logdensity"))
   ld_ttm_p  <- as.numeric(predict(M_TTM_p,  X_te_p, type = "logdensity"))
 
-  plot(ld_base_p, ld_base_p, pch = 16, col = "black",
-       xlab = "True log-Dichte",
-       ylab = "Geschaetzte log-Dichte",
-       main = "Permutation")
-  points(ld_base_p, ld_trtf_p, col = "blue", pch = 1)
-  points(ld_base_p, ld_ks_p,   col = "red",  pch = 2)
-  points(ld_base_p, ld_ttm_p,  col = "darkgreen", pch = 3)
-  abline(a = 0, b = 1)
-  legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
-         col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
+  scatter_data <- list(
+    ld_base   = ld_base,
+    ld_trtf   = ld_trtf,
+    ld_ks     = ld_ks,
+    ld_ttm    = ld_ttm,
+    ld_base_p = ld_base_p,
+    ld_trtf_p = ld_trtf_p,
+    ld_ks_p   = ld_ks_p,
+    ld_ttm_p  = ld_ttm_p
+  )
+
+  create_EDA_report(S$X_tr, G$config, scatter_data = scatter_data)
 
   print(round_df(tab_normal, digits = 3))
   print(round_df(tab_perm, digits = 3))

--- a/roadmap.md
+++ b/roadmap.md
@@ -261,7 +261,7 @@ FUNCTION evaluate_all(X_te, model_list):
 
 ---
 
-### **Script 7: 05\_main.R**  (Orchestrator)
+### **Script 7: main.R**  (Orchestrator)
 
 ```
 config <- list(

--- a/tests/testthat/test_baseline_limit.R
+++ b/tests/testthat/test_baseline_limit.R
@@ -1,5 +1,5 @@
 old_wd <- setwd("../..")
-source("05_main.R")
+source("main.R")
 
 set.seed(123)
 N <- 100

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -1,5 +1,5 @@
 old_wd <- setwd("../..")
-source("05_main.R")
+source("main.R")
 
 set.seed(42)
 G <- list(N = 20, config = config, seed = 42, split_ratio = 0.5)


### PR DESCRIPTION
## Summary
- rename `05_main.R` to `main.R`
- extend `create_EDA_report` to handle log-density plots
- call the new report function from `main.R`
- update docs and tests to use `main.R`

## Testing
- `Rscript -e "lintr::lint_dir('.')"`
- `Rscript tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_6842a3b5f0d48333ac6113464247fd71