### PR TITLE
Add runtime bullets and result tables to EDA report

### DIFF
--- a/EDA.R
+++ b/EDA.R
@@ -49,10 +49,62 @@ compute_param_values <- function(X, cfg) {
   params
 }
 
+round_df <- function(df, digits = 3) {
+  idx <- vapply(df, is.numeric, logical(1))
+  df[idx] <- lapply(df[idx], round, digits = digits)
+  df
+}
+
 create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
-                              scatter_data = NULL) {
+                              scatter_data = NULL,
+                              runtime_list = NULL,
+                              hyperparam_list = NULL,
+                              tab_normal = NULL,
+                              tab_perm = NULL,
+                              perm_vec = NULL) {
   params <- compute_param_values(X, cfg)
   pdf(output_file)
+
+  if (!is.null(runtime_list)) {
+    plot.new()
+    title(main = "Vorhersage-Laufzeiten")
+    y_pos <- 0.9
+    step <- 0.1
+    r_names <- names(runtime_list)
+    for (i in seq_along(runtime_list)) {
+      nm <- r_names[i]
+      hp <- if (!is.null(hyperparam_list) && !is.null(hyperparam_list[[nm]]))
+        hyperparam_list[[nm]] else ""
+      txt <- sprintf("\u2022 %s (%s): %0.2fs", nm, hp, runtime_list[[i]])
+      text(0.05, y_pos - step * (i - 1), txt, adj = 0)
+    }
+  }
+
+  if (!is.null(tab_normal)) {
+    plot.new()
+    title(main = "Normale iteration 1 \u2192 2 \u2192 3 \u2192 4")
+    tabn <- round_df(tab_normal, digits = 3)
+    y_pos <- 0.9
+    step <- 0.05
+    text(0.05, y_pos, paste(names(tabn), collapse = " | "), adj = 0)
+    for (i in seq_len(nrow(tabn))) {
+      text(0.05, y_pos - step * i, paste(tabn[i, ], collapse = " | "), adj = 0)
+    }
+  }
+
+  if (!is.null(tab_perm)) {
+    plot.new()
+    perm_text <- if (is.null(perm_vec)) "" else paste(perm_vec, collapse = " \u2192 ")
+    title(main = sprintf("Permutation %s", perm_text))
+    tabp <- round_df(tab_perm, digits = 3)
+    y_pos <- 0.9
+    step <- 0.05
+    text(0.05, y_pos, paste(names(tabp), collapse = " | "), adj = 0)
+    for (i in seq_len(nrow(tabp))) {
+      text(0.05, y_pos - step * i, paste(tabp[i, ], collapse = " | "), adj = 0)
+    }
+  }
+
   for (k in seq_along(params)) {
     p_df <- params[[k]]
     if (is.null(p_df)) next

--- a/main.R
+++ b/main.R
@@ -45,10 +45,18 @@ main <- function() {
   M_KS   <- fit_KS(S$X_tr, S$X_te, G$config)      # Script models/ks_model.R
   M_TTM  <- fit_TTM(S$X_tr, S$X_te)               # Script models/ttm_model.R
 
-  baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
-  trtf_ll     <- logL_TRTF_dim(M_TRTF, S$X_te)
-  ks_ll       <- logL_KS_dim(M_KS, S$X_te)
-  ttm_ll      <- logL_TTM_dim(M_TTM, S$X_te)
+  t_true  <- system.time(
+    baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
+  )["elapsed"]
+  t_trtf <- system.time(
+    trtf_ll     <- logL_TRTF_dim(M_TRTF, S$X_te)
+  )["elapsed"]
+  t_ks   <- system.time(
+    ks_ll       <- logL_KS_dim(M_KS, S$X_te)
+  )["elapsed"]
+  t_ttm  <- system.time(
+    ttm_ll      <- logL_TTM_dim(M_TTM, S$X_te)
+  )["elapsed"]
 
   tab_normal <- data.frame(
     dim = as.character(seq_along(G$config)),
@@ -143,7 +151,21 @@ main <- function() {
     ld_ttm_p  = ld_ttm_p
   )
 
-  create_EDA_report(S$X_tr, G$config, scatter_data = scatter_data)
+  runtime_list <- c("TRUE" = t_true, TRTF = t_trtf, KS = t_ks, TTM = t_ttm)
+  hyperparam_list <- list(
+    "TRUE" = "keine",
+    TRTF = "ntree=50, mtry=sqrt(K-1), minsplit=25, minbucket=20, maxdepth=4",
+    KS   = "bw.nrd0",
+    TTM  = "lr=0.01, epochs=200, patience=10"
+  )
+
+  create_EDA_report(S$X_tr, G$config,
+                    scatter_data = scatter_data,
+                    runtime_list = runtime_list,
+                    hyperparam_list = hyperparam_list,
+                    tab_normal = tab_normal,
+                    tab_perm = tab_perm,
+                    perm_vec = perm)
 
 
   print(round_df(tab_normal, digits = 3))


### PR DESCRIPTION
## Summary
- erweitere `create_EDA_report` um Laufzeit‐ und Tabellenanzeige
- messe Vorhersagezeiten der vier Modelle in `main.R`
- reiche diese Informationen an den EDA‑Report weiter

## Testing
- `Rscript -e 'lintr::lint_dir()'`
- `Rscript tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_6842adce10508333b7b70fe257619ba6