### PR TITLE
Implementierte neue EDA-Grafiken

### DIFF
--- a/EDA.R
+++ b/EDA.R
@@ -1,53 +1,12 @@
 #' Exploratory Data Analysis for Generated Samples
 #'
-#' Computes distribution of per-sample parameters and pairwise
-#' scatter plots with parameter overlay. Results are written to a PDF.
+#' Creates tables and scatter plots comparing estimated log-densities with
+#' the wahren Werten. Results are written to a PDF.
 #'
 #' @param X matrix of generated samples
 #' @param cfg configuration list as in `gen_samples`
 #' @param output_file path to PDF file
 #' @return invisibly the path to the created PDF
-compute_param_values <- function(X, cfg) {
-  stopifnot(is.matrix(X), is.list(cfg))
-  N <- nrow(X)
-  K <- length(cfg)
-  params <- vector("list", K)
-  for (k in seq_len(K)) {
-    c_k <- cfg[[k]]
-    if (is.null(c_k$parm)) next
-    prev_names <- paste0("X", seq_len(k - 1))
-    # determine names via first sample
-    if (k == 1) {
-      prev_df <- data.frame()
-    } else {
-      prev_df <- as.data.frame(as.list(X[1, seq_len(k - 1)]))
-      names(prev_df) <- prev_names
-    }
-    args0 <- c_k$parm(prev_df)
-    if (c_k$distr == "gamma" && all(c("shape1", "shape2") %in% names(args0))) {
-      args0 <- list(shape = args0$shape1, scale = args0$shape2)
-    }
-    arg_names <- names(args0)
-    mat <- matrix(NA_real_, nrow = N, ncol = length(arg_names))
-    colnames(mat) <- arg_names
-    for (i in seq_len(N)) {
-      if (k == 1) {
-        prev_df <- data.frame()
-      } else {
-        prev_df <- as.data.frame(as.list(X[i, seq_len(k - 1)]))
-        names(prev_df) <- prev_names
-      }
-      args <- c_k$parm(prev_df)
-      if (c_k$distr == "gamma" && all(c("shape1", "shape2") %in% names(args))) {
-        args <- list(shape = args$shape1, scale = args$shape2)
-      }
-      args <- lapply(args, function(p) if (!is.finite(p) || p <= 0) 1e-3 else p)
-      mat[i, ] <- as.numeric(args[arg_names])
-    }
-    params[[k]] <- as.data.frame(mat)
-  }
-  params
-}
 
 round_df <- function(df, digits = 3) {
   idx <- vapply(df, is.numeric, logical(1))
@@ -62,8 +21,7 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
                               tab_normal = NULL,
                               tab_perm = NULL,
                               perm_vec = NULL) {
-  params <- compute_param_values(X, cfg)
-  pdf(output_file)
+  pdf(output_file, paper = "a4")
 
   if (!is.null(runtime_list)) {
     plot.new()
@@ -105,53 +63,48 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
     }
   }
 
-  for (k in seq_along(params)) {
-    p_df <- params[[k]]
-    if (is.null(p_df)) next
-    for (nm in names(p_df)) {
-      hist(p_df[[nm]], breaks = 30, main = sprintf("%s for X%d", nm, k),
-           xlab = nm, col = "grey", border = "white")
-    }
-  }
-  for (k in 2:ncol(X)) {
-    p_df <- params[[k]]
-    if (is.null(p_df) || ncol(p_df) < 1) next
-    color_val <- p_df[[1]]
-    param_name <- names(p_df)[1]
-    cols <- colorRampPalette(c("blue", "red"))(100)
-    idx <- cut(color_val, breaks = 100, labels = FALSE, include.lowest = TRUE)
-    plot(X[, k - 1], X[, k], col = cols[idx], pch = 16,
-         xlab = paste0("X", k - 1), ylab = paste0("X", k),
-         main = sprintf("X%d vs X%d by %s", k, k - 1, param_name))
-    legend("topright", legend = c(sprintf("low %0.2f", min(color_val)),
-                                 sprintf("high %0.2f", max(color_val))),
-           fill = cols[c(1, 100)], bty = "n", title = param_name)
-  }
 
- if (!is.null(scatter_data)) {
+
+  if (!is.null(scatter_data)) {
+    par(mfrow = c(3, 2))
     with(scatter_data, {
-      plot(ld_base, ld_base, pch = 16, col = "black",
+      plot(ld_base, ld_trtf, pch = 16, col = "blue",
            xlab = "True log-Dichte",
            ylab = "Geschaetzte log-Dichte",
-           main = "Originalreihenfolge")
-      points(ld_base, ld_trtf, col = "blue", pch = 1)
-      points(ld_base, ld_ks,   col = "red",  pch = 2)
-      points(ld_base, ld_ttm,  col = "darkgreen", pch = 3)
+           main = "TRTF")
       abline(a = 0, b = 1)
-      legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
-             col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
 
-      plot(ld_base_p, ld_base_p, pch = 16, col = "black",
+      plot(ld_base_p, ld_trtf_p, pch = 16, col = "blue",
            xlab = "True log-Dichte",
            ylab = "Geschaetzte log-Dichte",
-           main = "Permutation")
-      points(ld_base_p, ld_trtf_p, col = "blue", pch = 1)
-      points(ld_base_p, ld_ks_p,   col = "red",  pch = 2)
-      points(ld_base_p, ld_ttm_p,  col = "darkgreen", pch = 3)
+           main = "TRTF (Perm.)")
       abline(a = 0, b = 1)
-      legend("topleft", legend = c("true_baseline", "trtf", "ks", "ttm"),
-             col = c("black", "blue", "red", "darkgreen"), pch = c(16, 1, 2, 3))
+
+      plot(ld_base, ld_ks, pch = 16, col = "red",
+           xlab = "True log-Dichte",
+           ylab = "Geschaetzte log-Dichte",
+           main = "KS")
+      abline(a = 0, b = 1)
+
+      plot(ld_base_p, ld_ks_p, pch = 16, col = "red",
+           xlab = "True log-Dichte",
+           ylab = "Geschaetzte log-Dichte",
+           main = "KS (Perm.)")
+      abline(a = 0, b = 1)
+
+      plot(ld_base, ld_ttm, pch = 16, col = "darkgreen",
+           xlab = "True log-Dichte",
+           ylab = "Geschaetzte log-Dichte",
+           main = "TTM")
+      abline(a = 0, b = 1)
+
+      plot(ld_base_p, ld_ttm_p, pch = 16, col = "darkgreen",
+           xlab = "True log-Dichte",
+           ylab = "Geschaetzte log-Dichte",
+           main = "TTM (Perm.)")
+      abline(a = 0, b = 1)
     })
+    par(mfrow = c(1, 1))
   }
   
   dev.off()


### PR DESCRIPTION
## Zusammenfassung
- Zeichenkette `true_baseline` zu `true` entfernt
- unnötige Histogramme und Parameterdarstellungen gestrichen
- sechs Vergleichsplots (TRTF/KS/TTM vs. TRUE) angeordnet
- PDF-Ausgabe auf A4-Hochformat gestellt

## Test
- `lintr::lint_package()`
- `R -q -f tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_6842b03c27f88333a1904ea3a04794eb