### PR TITLE
Add multi-section layout in EDA report

### DIFF
--- a/EDA.R
+++ b/EDA.R
@@ -23,44 +23,55 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
                               perm_vec = NULL) {
   pdf(output_file, paper = "a4")
 
-  if (!is.null(runtime_list)) {
-    plot.new()
-    title(main = "Vorhersage-Laufzeiten")
-    y_pos <- 0.9
-    step <- 0.1
-    r_names <- names(runtime_list)
-    for (i in seq_along(runtime_list)) {
-      nm <- r_names[i]
-      hp <- if (!is.null(hyperparam_list) && !is.null(hyperparam_list[[nm]]))
-        hyperparam_list[[nm]] else ""
-      txt <- sprintf("\u2022 %s (%s): %0.2fs", nm, hp, runtime_list[[i]])
-      text(0.05, y_pos - step * (i - 1), txt, adj = 0)
-    }
-  }
+  sections <- list(runtime_list, tab_normal, tab_perm)
+  n_sec <- sum(!vapply(sections, is.null, logical(1)))
 
-  if (!is.null(tab_normal)) {
-    plot.new()
-    title(main = "Normale iteration 1 \u2192 2 \u2192 3 \u2192 4")
-    tabn <- round_df(tab_normal, digits = 3)
-    y_pos <- 0.9
-    step <- 0.05
-    text(0.05, y_pos, paste(names(tabn), collapse = " | "), adj = 0)
-    for (i in seq_len(nrow(tabn))) {
-      text(0.05, y_pos - step * i, paste(tabn[i, ], collapse = " | "), adj = 0)
-    }
-  }
+  if (n_sec > 0) {
+    old_par <- par(no.readonly = TRUE)
+    on.exit(par(old_par), add = TRUE)
+    par(mfrow = c(n_sec, 1), mar = c(2, 1, 3, 1))
 
-  if (!is.null(tab_perm)) {
-    plot.new()
-    perm_text <- if (is.null(perm_vec)) "" else paste(perm_vec, collapse = " \u2192 ")
-    title(main = sprintf("Permutation %s", perm_text))
-    tabp <- round_df(tab_perm, digits = 3)
-    y_pos <- 0.9
-    step <- 0.05
-    text(0.05, y_pos, paste(names(tabp), collapse = " | "), adj = 0)
-    for (i in seq_len(nrow(tabp))) {
-      text(0.05, y_pos - step * i, paste(tabp[i, ], collapse = " | "), adj = 0)
+    if (!is.null(runtime_list)) {
+      plot.new()
+      title(main = "Vorhersage-Laufzeiten")
+      y_pos <- 0.9
+      step <- 0.1
+      r_names <- names(runtime_list)
+      for (i in seq_along(runtime_list)) {
+        nm <- r_names[i]
+        hp <- if (!is.null(hyperparam_list) && !is.null(hyperparam_list[[nm]]))
+          hyperparam_list[[nm]] else ""
+        txt <- sprintf("\u2022 %s (%s): %0.2fs", nm, hp, runtime_list[[i]])
+        text(0.05, y_pos - step * (i - 1), txt, adj = 0)
+      }
     }
+
+    if (!is.null(tab_normal)) {
+      plot.new()
+      title(main = "Normale iteration 1 \u2192 2 \u2192 3 \u2192 4")
+      tabn <- round_df(tab_normal, digits = 3)
+      y_pos <- 0.9
+      step <- 0.05
+      text(0.05, y_pos, paste(names(tabn), collapse = " | "), adj = 0)
+      for (i in seq_len(nrow(tabn))) {
+        text(0.05, y_pos - step * i, paste(tabn[i, ], collapse = " | "), adj = 0)
+      }
+    }
+
+    if (!is.null(tab_perm)) {
+      plot.new()
+      perm_text <- if (is.null(perm_vec)) "" else paste(perm_vec, collapse = " \u2192 ")
+      title(main = sprintf("Permutation %s", perm_text))
+      tabp <- round_df(tab_perm, digits = 3)
+      y_pos <- 0.9
+      step <- 0.05
+      text(0.05, y_pos, paste(names(tabp), collapse = " | "), adj = 0)
+      for (i in seq_len(nrow(tabp))) {
+        text(0.05, y_pos - step * i, paste(tabp[i, ], collapse = " | "), adj = 0)
+      }
+    }
+
+    par(mfrow = c(1, 1))
   }
 
 


### PR DESCRIPTION
## Summary
- arrange runtime tables and permutations on a single A4 page
- keep scatter plots unaffected

## Testing
- `Rscript tests/testthat.R` *(partial output shown)*

------
https://chatgpt.com/codex/tasks/task_e_6842b3daeb8c833394fa325c89142f70