### PR TITLE
Neue LogL-Tabellen als kableExtra

### DIFF
--- a/05_logL_table.R
+++ b/05_logL_table.R
@@ -1,0 +1,90 @@
+#' Merge log-likelihood tables and format via kableExtra
+#'
+#' This helper computes runtimes for the permutation order and
+#' combines `tab_normal` and `tab_perm` into one table. The result is
+#' returned as a `kableExtra` object ready for LaTeX/HTML output.
+#'
+#' @param tab_normal table from `main()` in original order
+#' @param tab_perm   table from `main()` with permuted variables
+#' @param M_TRUE_p   TRUE model fitted on permuted data
+#' @param M_TRTF_p   TRTF model fitted on permuted data
+#' @param M_KS_p     KS model fitted on permuted data
+#' @param M_TTM_p    TTM model fitted on permuted data
+#' @param X_te_p     test matrix for the permutation
+#' @param t_normal   named numeric vector with runtimes of the
+#'                   normal order (names: true, trtf, ks, ttm)
+#' @return `kableExtra` table object
+#' @export
+combine_logL_tables <- function(tab_normal, tab_perm,
+                                M_TRUE_p, M_TRTF_p, M_KS_p, M_TTM_p, X_te_p,
+                                t_normal) {
+  if (!requireNamespace("kableExtra", quietly = TRUE))
+    install.packages("kableExtra", repos = "https://cloud.r-project.org")
+
+  library(dplyr)
+  library(tibble)
+  library(kableExtra)
+
+  t_true_p <- system.time(logL_TRUE_dim(M_TRUE_p, X_te_p))["elapsed"]
+  t_trtf_p <- system.time(logL_TRTF_dim(M_TRTF_p, X_te_p))["elapsed"]
+  t_ks_p   <- system.time(logL_KS_dim(M_KS_p,   X_te_p))["elapsed"]
+  t_ttm_p  <- system.time(logL_TTM_dim(M_TTM_p, X_te_p))["elapsed"]
+
+  clean_cols <- function(df, suffix) {
+    df %>%
+      rename(
+        distr = distribution,
+        true  = logL_baseline,
+        trtf  = logL_trtf,
+        ks    = logL_ks,
+        ttm   = logL_ttm
+      ) %>%
+      rename_with(~ paste0(.x, "_", suffix),
+                  c(true, trtf, ks, ttm))
+  }
+
+  tab_norm <- clean_cols(tab_normal, "norm")
+  tab_perm <- clean_cols(tab_perm,   "perm")
+
+  tab_all <- left_join(tab_norm, tab_perm, by = c("dim", "distr"))
+  tab_all <- tab_all %>%
+    mutate(across(where(is.numeric), replace_na, 0)) %>%
+    mutate(distr = replace_na(distr, "SUM"))
+
+  tab_all <- tab_all %>%
+    add_row(
+      dim        = "runtime",
+      distr      = "",
+      true_norm  = t_normal["true"] * 1000,
+      true_perm  = t_true_p * 1000,
+      trtf_norm  = t_normal["trtf"] * 1000,
+      trtf_perm  = t_trtf_p * 1000,
+      ks_norm    = t_normal["ks"] * 1000,
+      ks_perm    = t_ks_p * 1000,
+      ttm_norm   = t_normal["ttm"] * 1000,
+      ttm_perm   = t_ttm_p * 1000
+    )
+
+  tab_all <- tab_all %>%
+    mutate(across(where(is.numeric), ~ round(.x, 3)))
+
+  header_lvl1 <- c(" " = 2,
+                   "true" = 2,
+                   "trtf" = 2,
+                   "ks"   = 2,
+                   "ttm"  = 2)
+  header_lvl2 <- c(
+    "dim" = 1,
+    "distr" = 1,
+    "normal" = 1, "permu" = 1,
+    "normal" = 1, "permu" = 1,
+    "normal" = 1, "permu" = 1,
+    "normal" = 1, "permu" = 1
+  )
+
+  tab_all %>%
+    kbl(caption = "Average logL", align = "c", booktabs = TRUE) %>%
+    add_header_above(header_lvl1, align = "c") %>%
+    add_header_above(header_lvl2, align = "c") %>%
+    kable_styling(full_width = FALSE, position = "center")
+}

--- a/tests/testthat/test_combine_tables.R
+++ b/tests/testthat/test_combine_tables.R
@@ -1,0 +1,102 @@
+old_wd <- setwd("../..")
+source("05_logL_table.R")
+source("00_globals.R")
+source("01_data_generation.R")
+source("02_split.R")
+source("models/true_model.R")
+source("models/trtf_model.R")
+source("models/ks_model.R")
+source("models/ttm_model.R")
+source("04_evaluation.R")
+
+set.seed(1)
+G <- setup_global()
+G$N <- 10
+X <- gen_samples(G)
+S <- train_test_split(X, G$split_ratio, G$seed)
+
+M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)
+M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)
+M_KS   <- fit_KS(S$X_tr, S$X_te, G$config)
+M_TTM  <- fit_TTM(S$X_tr, S$X_te)
+
+t_true  <- system.time(logL_TRUE_dim(M_TRUE, S$X_te))["elapsed"]
+t_trtf <- system.time(logL_TRTF_dim(M_TRTF, S$X_te))["elapsed"]
+t_ks   <- system.time(logL_KS_dim(M_KS,   S$X_te))["elapsed"]
+t_ttm  <- system.time(logL_TTM_dim(M_TTM, S$X_te))["elapsed"]
+
+baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
+trtf_ll     <- logL_TRTF_dim(M_TRTF, S$X_te)
+ks_ll       <- logL_KS_dim(M_KS, S$X_te)
+ttm_ll      <- logL_TTM_dim(M_TTM, S$X_te)
+
+tab_normal <- data.frame(
+  dim = as.character(seq_along(G$config)),
+  distribution = sapply(G$config, `[[`, "distr"),
+  logL_baseline = baseline_ll,
+  logL_trtf = trtf_ll,
+  logL_ks = ks_ll,
+  logL_ttm = ttm_ll,
+  stringsAsFactors = FALSE
+)
+
+sum_row <- setNames(vector("list", ncol(tab_normal)), names(tab_normal))
+for (nm in names(tab_normal)) {
+  if (nm == "dim") {
+    sum_row[[nm]] <- "k"
+  } else if (is.numeric(tab_normal[[nm]])) {
+    sum_row[[nm]] <- sum(tab_normal[[nm]])
+  } else {
+    sum_row[[nm]] <- NA
+  }
+}
+tab_normal <- rbind(tab_normal, as.data.frame(sum_row, stringsAsFactors = FALSE))
+
+X_tr_p <- S$X_tr[, c(2,1,3,4)[seq_len(ncol(S$X_tr))], drop = FALSE]
+X_te_p <- S$X_te[, c(2,1,3,4)[seq_len(ncol(S$X_te))], drop = FALSE]
+colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
+colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
+
+M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
+M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
+M_KS_p   <- fit_KS(X_tr_p, X_te_p, G$config)
+M_TTM_p  <- fit_TTM(X_tr_p, X_te_p)
+
+baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
+trtf_ll_p     <- logL_TRTF_dim(M_TRTF_p, X_te_p)
+ks_ll_p       <- logL_KS_dim(M_KS_p, X_te_p)
+ttm_ll_p      <- logL_TTM_dim(M_TTM_p, X_te_p)
+
+tab_perm <- data.frame(
+  dim = as.character(seq_along(G$config)),
+  distribution = sapply(G$config, `[[`, "distr"),
+  logL_baseline = baseline_ll_p,
+  logL_trtf = trtf_ll_p,
+  logL_ks = ks_ll_p,
+  logL_ttm = ttm_ll_p,
+  stringsAsFactors = FALSE
+)
+
+sum_row <- setNames(vector("list", ncol(tab_perm)), names(tab_perm))
+for (nm in names(tab_perm)) {
+  if (nm == "dim") {
+    sum_row[[nm]] <- "k"
+  } else if (is.numeric(tab_perm[[nm]])) {
+    sum_row[[nm]] <- sum(tab_perm[[nm]])
+  } else {
+    sum_row[[nm]] <- NA
+  }
+}
+tab_perm <- rbind(tab_perm, as.data.frame(sum_row, stringsAsFactors = FALSE))
+
+vec_normal <- c(true = t_true, trtf = t_trtf, ks = t_ks, ttm = t_ttm)
+
+kbl_obj <- combine_logL_tables(tab_normal, tab_perm,
+                              M_TRUE_p, M_TRTF_p, M_KS_p, M_TTM_p, X_te_p,
+                              vec_normal)
+
+setwd(old_wd)
+
+test_that("combine_logL_tables returns kable", {
+  expect_s3_class(kbl_obj, "knitr_kable")
+})


### PR DESCRIPTION
## Zusammenfassung
- kableExtra-Hilfsfunktion `combine_logL_tables` implementiert
- Beispieltest `test_combine_tables.R` demonstriert Grundfunktion

## Testing
- `lintr::lint_package()` ausgefuehrt ohne Ausgabe
- `testthat::test_dir('tests/testthat')` schlug wegen fehlender Systembibliotheken fuer `partykit` fehl

------
https://chatgpt.com/codex/tasks/task_e_6842c4c5cbe083339da9ca0a1e8c81f3