### PR TITLE
Tabellen-Layout in EDA angepasst

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -110,8 +110,11 @@ combine_logL_tables <- function(tab_normal, tab_perm,
     mutate(distr = replace_na(distr, "SUM"))
 
   tab_all <- tab_all %>%
+    rename_with(~ sub("_norm$", "", .x), ends_with("_norm"))
+
+  tab_all <- tab_all %>%
     add_row(
-      dim        = "runtime",
+      dim        = "runtime (ms)",
       distr      = "",
       true_norm  = t_normal["true"] * 1000,
       true_perm  = t_true_p * 1000,
@@ -124,7 +127,7 @@ combine_logL_tables <- function(tab_normal, tab_perm,
     )
 
   tab_all <- tab_all %>%
-    mutate(across(where(is.numeric), ~ round(.x, 3)))
+    mutate(across(where(is.numeric), ~ round(.x, 0)))
 
   header_lvl1 <- c(" " = 2,
                    "true" = 2,
@@ -141,7 +144,7 @@ combine_logL_tables <- function(tab_normal, tab_perm,
   )
 
   tab_all %>%
-    kbl(caption = "Average logL", align = "c", booktabs = TRUE) %>%
+    kbl(caption = "Average -logLikelihood", align = "c", booktabs = TRUE) %>%
     add_header_above(header_lvl1, align = "c") %>%
     add_header_above(header_lvl2, align = "c") %>%
     kable_styling(full_width = FALSE, position = "center") -> kbl_out

--- a/EDA.R
+++ b/EDA.R
@@ -46,7 +46,10 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
 
   pdf(output_file, width = 8, height = 11)
   if (!is.null(table_kbl)) {
-    tbl <- gridExtra::tableGrob(attr(table_kbl, "tab_data"))
+    tbl <- gridExtra::tableGrob(
+      attr(table_kbl, "tab_data"), rows = NULL,
+      theme = gridExtra::ttheme_default(base_size = 8)
+    )
     gridExtra::grid.arrange(tbl)
   }
   if (!is.null(plots))

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -22,5 +22,5 @@ test_that("main outputs combined kable table", {
   expect_s3_class(res, "knitr_kable")
   tab_data <- attr(res, "tab_data")
   expect_s3_class(tab_data, "data.frame")
-  expect_true(all(is.finite(tab_data$true_norm[1:length(G$config)])))
+  expect_true(all(is.finite(tab_data$true[1:length(G$config)])))
 })


### PR DESCRIPTION
## Summary
- Spaltennamen vereinheitlicht und Runtimerow umbenannt
- Werte in der Ergebnistabelle auf ganze Zahlen gerundet
- Caption korrigiert und PDF-Tabellenschrift verkleinert
- Test an neue Tabellenspalten angepasst

## Testing
- `lintr::lint_dir(); testthat::test_dir('tests/testthat', reporter='summary')` *(failed: there is no package called 'trtf')*

------
https://chatgpt.com/codex/tasks/task_e_68441ec6a6448333a40411a815e713d6