### PR TITLE
Bugfix für replace_na Fehler

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -84,8 +84,8 @@ combine_logL_tables <- function(tab_normal, tab_perm,
 
   tab_all <- left_join(tab_norm, tab_perm, by = c("dim", "distr"))
   tab_all <- tab_all %>%
-    mutate(across(where(is.numeric), replace_na, 0)) %>%
-    mutate(distr = replace_na(distr, "SUM"))
+    mutate(across(where(is.numeric), ~ coalesce(.x, 0))) %>%
+    mutate(distr = coalesce(distr, "SUM"))
 
   tab_all <- tab_all %>%
     add_row(


### PR DESCRIPTION
## Summary
- ersetze `replace_na` durch `coalesce` in `combine_logL_tables`

## Testing
- `lintr::lint('04_evaluation.R')`
- `testthat::test_dir('tests/testthat')` *(scheiterte: fehlende Systembibliotheken für partykit)*

------
https://chatgpt.com/codex/tasks/task_e_6844064814e4833381b565c20c674dab