### PR TITLE
Set config only in main

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -2,15 +2,14 @@
 # Notation follows Theory.md
 
 ## Bibliotheken -------------------------------------------------------------
+pkgs <- c("trtf", "ggplot2", "gridExtra", "kableExtra", "dplyr",
+          "tibble", "testthat", "tidyr")
+for (p in pkgs) {
+  if (!requireNamespace(p, quietly = TRUE))
+    install.packages(p, repos = "https://cloud.r-project.org")
+  library(p, character.only = TRUE)
+}
 library(parallel)
-library(trtf)
-library(ggplot2)
-library(gridExtra)
-library(kableExtra)
-library(dplyr)
-library(tibble)
-library(testthat)
-library(tidyr)
 
 softplus <- function(x) log1p(exp(x))
 

--- a/main.R
+++ b/main.R
@@ -1,3 +1,6 @@
+if (!requireNamespace("gridExtra", quietly = TRUE))
+  install.packages("gridExtra", repos = "https://cloud.r-project.org")
+
 source("00_globals.R")
 source("01_data_generation.R")
 source("02_split.R")

--- a/tests/testthat/helper_config.R
+++ b/tests/testthat/helper_config.R
@@ -1,0 +1,7 @@
+source("../../00_globals.R")
+config <- list(
+  list(distr = "norm", parm = NULL),
+  list(distr = "exp",  parm = function(d) list(rate = softplus(d$X1))),
+  list(distr = "beta", parm = function(d) list(shape1 = softplus(d$X2), shape2 = softplus(d$X1))),
+  list(distr = "gamma", parm = function(d) list(shape = softplus(d$X3), scale = softplus(d$X2)))
+)

--- a/tests/testthat/test_globals.R
+++ b/tests/testthat/test_globals.R
@@ -2,7 +2,7 @@ test_that("setup_global returns expected list", {
   out <- setup_global()
   expect_type(out, "list")
   expect_equal(out$N, 500)
-  expect_equal(out$config, config)
+  expect_true(identical(out$config, config))
   expect_equal(out$seed, 42)
   expect_equal(out$split_ratio, 0.5)
   expect_equal(out$P_max, 6)


### PR DESCRIPTION
## Summary
- install missing packages when loading `00_globals.R`
- define test helper with config for unit tests
- compare config via `identical` in test

## Testing
- `R -q -e "lintr::lint('00_globals.R')"` *(fails: object_name_linter complaints)*
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: several modeling tests)*

------
https://chatgpt.com/codex/tasks/task_e_68443bc1575c8333bdb444499aca21d4