### PR TITLE
EDA-Report erweitert

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -127,7 +127,13 @@ combine_logL_tables <- function(tab_normal, tab_perm,
     )
 
   tab_all <- tab_all %>%
-    mutate(across(where(is.numeric), ~ round(.x, 0)))
+    identity()
+
+  num_cols <- vapply(tab_all, is.numeric, logical(1))
+  for (col in names(tab_all)[num_cols]) {
+    tab_all[-nrow(tab_all), col] <- round(tab_all[-nrow(tab_all), col], 3)
+    tab_all[nrow(tab_all), col] <- round(tab_all[nrow(tab_all), col], 0)
+  }
 
   header_lvl1 <- c(" " = 2,
                    "true" = 2,
@@ -144,7 +150,7 @@ combine_logL_tables <- function(tab_normal, tab_perm,
   )
 
   tab_all %>%
-    kbl(caption = "Average -logLikelihood", align = "c", booktabs = TRUE) %>%
+    kbl(caption = "Average logL", align = "c", booktabs = TRUE) %>%
     add_header_above(header_lvl1, align = "c") %>%
     add_header_above(header_lvl2, align = "c") %>%
     kable_styling(full_width = FALSE, position = "center") -> kbl_out

--- a/EDA.R
+++ b/EDA.R
@@ -44,11 +44,11 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
     })
   }
 
-  pdf(output_file, width = 8, height = 11)
+  pdf(output_file, width = 8, height = 11, title = "Average logL")
   if (!is.null(table_kbl)) {
     tbl <- gridExtra::tableGrob(
       attr(table_kbl, "tab_data"), rows = NULL,
-      theme = gridExtra::ttheme_default(base_size = 8)
+      theme = gridExtra::ttheme_default(base_size = 9)
     )
     gridExtra::grid.arrange(tbl)
   }

--- a/main.R
+++ b/main.R
@@ -138,8 +138,14 @@ main <- function() {
                     scatter_data = scatter_data,
                     table_kbl = kbl_tab)
 
-
-  invisible(kbl_tab)
+  res <- list(
+    kbl = kbl_tab,
+    normal = tab_normal,
+    permutation = tab_perm
+  )
+  class(res) <- c("knitr_kable", class(kbl_tab))
+  attr(res, "tab_data") <- attr(kbl_tab, "tab_data")
+  res
 }
 
 


### PR DESCRIPTION
## Summary
- kleinere Layout-Änderungen am EDA-Report
- Rundung der LogL-Tabelle je Zeile differenziert
- main() liefert jetzt neben der Tabelle auch Einzelresultate

## Testing
- `R -q -e "source('tests/testthat.R')"` *(fail)*

------
https://chatgpt.com/codex/tasks/task_e_68444ace251c8333aa3c011c5ef112d8