### PR TITLE
EDA-Report erweitert

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -25,10 +25,11 @@ setup_global <- function() {
   P_max <- 6
   H_grid <- seq_len(P_max)
   model_ids <- c("TRUE")
+  cfg <- get("config", envir = parent.frame())
 
   list(
     N = N,
-    config = config,
+    config = cfg,
     seed = seed,
     split_ratio = split_ratio,
     H_grid = H_grid,

--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -127,7 +127,13 @@ combine_logL_tables <- function(tab_normal, tab_perm,
     )
 
   tab_all <- tab_all %>%
-    mutate(across(where(is.numeric), ~ round(.x, 0)))
+    identity()
+
+  num_cols <- vapply(tab_all, is.numeric, logical(1))
+  for (col in names(tab_all)[num_cols]) {
+    tab_all[-nrow(tab_all), col] <- round(tab_all[-nrow(tab_all), col], 3)
+    tab_all[nrow(tab_all), col] <- round(tab_all[nrow(tab_all), col], 0)
+  }
 
   header_lvl1 <- c(" " = 2,
                    "true" = 2,
@@ -144,7 +150,7 @@ combine_logL_tables <- function(tab_normal, tab_perm,
   )
 
   tab_all %>%
-    kbl(caption = "Average -logLikelihood", align = "c", booktabs = TRUE) %>%
+    kbl(caption = "Average logL", align = "c", booktabs = TRUE) %>%
     add_header_above(header_lvl1, align = "c") %>%
     add_header_above(header_lvl2, align = "c") %>%
     kable_styling(full_width = FALSE, position = "center") -> kbl_out

--- a/EDA.R
+++ b/EDA.R
@@ -44,11 +44,11 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
     })
   }
 
-  pdf(output_file, width = 8, height = 11)
+  pdf(output_file, width = 8, height = 11, title = "Average logL")
   if (!is.null(table_kbl)) {
     tbl <- gridExtra::tableGrob(
       attr(table_kbl, "tab_data"), rows = NULL,
-      theme = gridExtra::ttheme_default(base_size = 8)
+      theme = gridExtra::ttheme_default(base_size = 9)
     )
     gridExtra::grid.arrange(tbl)
   }

--- a/main.R
+++ b/main.R
@@ -138,8 +138,15 @@ main <- function() {
                     scatter_data = scatter_data,
                     table_kbl = kbl_tab)
 
-
-  invisible(kbl_tab)
+  res <- list(
+    kbl = kbl_tab,
+    normal = tab_normal,
+    permutation = tab_perm
+  )
+  class(res) <- class(kbl_tab)
+  attr(res, "format") <- attr(kbl_tab, "format")
+  attr(res, "tab_data") <- attr(kbl_tab, "tab_data")
+  res
 }
 
 

--- a/models/true_model.R
+++ b/models/true_model.R
@@ -15,6 +15,7 @@ neg_loglik_uni <- function(par, x, distr) {
   } else if (distr == "exp") {
     rate <- par[1]
     if (rate <= 0) return(Inf)
+    x <- pmax(x, 1e-6)
     -sum(dexp(x, rate = rate, log = TRUE))
   } else if (distr == "beta") {
     a <- par[1]; b <- par[2]
@@ -36,6 +37,7 @@ neg_loglik_uni <- function(par, x, distr) {
   if (distr == "norm") {
     dnorm(x, mean = par[1], sd = par[2], log = TRUE)
   } else if (distr == "exp") {
+    x <- pmax(x, 1e-6)
     dexp(x, rate = par[1], log = TRUE)
   } else if (distr == "beta") {
     x <- pmin(pmax(x, 1e-6), 1 - 1e-6)
@@ -53,7 +55,9 @@ neg_loglik_uni <- function(par, x, distr) {
   if (distr == "norm") {
     c(mean(x), sd(x))
   } else if (distr == "exp") {
-    c(1 / mean(x))
+    rate <- 1 / mean(x)
+    if (!is.finite(rate) || rate <= 0) rate <- 1
+    c(rate)
   } else if (distr == "beta") {
     m <- mean(x); v <- var(x)
     common <- m * (1 - m) / v - 1


### PR DESCRIPTION
## Summary
- kleinere Layout-Änderungen am EDA-Report
- Rundung der LogL-Tabelle je Zeile differenziert
- main() liefert jetzt neben der Tabelle auch Einzelresultate
- setup_global nutzt nun das übergebene config-Objekt
- TRUE-Modell robust gegen negative Werte in Exponentialspalten

## Testing
- `R -q -e "source('tests/testthat.R')"`


------
https://chatgpt.com/codex/tasks/task_e_68444ace251c8333aa3c011c5ef112d8