### PR TITLE
Fix runtime row to show total model runtime

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -67,26 +67,17 @@ add_sum_row <- function(tab, label = "k") {
 #'
 #' @param tab_normal table created in `main()` using the original order
 #' @param tab_perm   table created in `main()` on permuted variables
-#' @param M_TRUE_p   TRUE model fitted on permuted data
-#' @param M_TRTF_p   TRTF model fitted on permuted data
-#' @param M_KS_p     KS model fitted on permuted data
-#' @param M_TTM_p    TTM model fitted on permuted data
-#' @param X_te_p     test matrix corresponding to the permutation
-#' @param t_normal   named numeric vector with runtimes of the normal
-#'                   order (names: true, trtf, ks, ttm)
+#' @param t_normal named numeric vector with runtimes in normal order
+#'                 (names: true, trtf, ks, ttm)
+#' @param t_perm   named numeric vector with runtimes in permutation order
+#'                 (names: true, trtf, ks, ttm)
 #' @return `kableExtra` table with average log-likelihoods and runtimes
 #' @export
 combine_logL_tables <- function(tab_normal, tab_perm,
-                                M_TRUE_p, M_TRTF_p, M_KS_p, M_TTM_p, X_te_p,
-                                t_normal) {
+                                t_normal, t_perm) {
   if (!requireNamespace("kableExtra", quietly = TRUE))
     install.packages("kableExtra", repos = "https://cloud.r-project.org")
 
-
-  t_true_p <- system.time(logL_TRUE_dim(M_TRUE_p, X_te_p))["elapsed"]
-  t_trtf_p <- system.time(logL_TRTF_dim(M_TRTF_p, X_te_p))["elapsed"]
-  t_ks_p   <- system.time(logL_KS_dim(M_KS_p,   X_te_p))["elapsed"]
-  t_ttm_p  <- system.time(logL_TTM_dim(M_TTM_p, X_te_p))["elapsed"]
 
   clean_cols <- function(df, suffix) {
     df %>%
@@ -117,13 +108,13 @@ combine_logL_tables <- function(tab_normal, tab_perm,
       dim       = "runtime (ms)",
       distr     = "",
       true      = t_normal["true"] * 1000,
-      true_perm = t_true_p * 1000,
+      true_perm = t_perm["true"] * 1000,
       trtf      = t_normal["trtf"] * 1000,
-      trtf_perm = t_trtf_p * 1000,
+      trtf_perm = t_perm["trtf"] * 1000,
       ks        = t_normal["ks"] * 1000,
-      ks_perm   = t_ks_p * 1000,
+      ks_perm   = t_perm["ks"] * 1000,
       ttm       = t_normal["ttm"] * 1000,
-      ttm_perm  = t_ttm_p * 1000
+      ttm_perm  = t_perm["ttm"] * 1000
     )
 
   tab_all <- tab_all %>%

--- a/tests/testthat/test_combine_tables.R
+++ b/tests/testthat/test_combine_tables.R
@@ -14,20 +14,25 @@ G$n <- 10
 X <- gen_samples(G)
 S <- train_test_split(X, G$split_ratio, G$seed)
 
-M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)
-M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)
-M_KS   <- fit_KS(S$X_tr, S$X_te, G$config)
-M_TTM  <- fit_TTM(S$X_tr, S$X_te)
+t_true <- system.time({
+  M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)
+  baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
+})[["elapsed"]]
 
-t_true  <- system.time(logL_TRUE_dim(M_TRUE, S$X_te))["elapsed"]
-t_trtf <- system.time(logL_TRTF_dim(M_TRTF, S$X_te))["elapsed"]
-t_ks   <- system.time(logL_KS_dim(M_KS,   S$X_te))["elapsed"]
-t_ttm  <- system.time(logL_TTM_dim(M_TTM, S$X_te))["elapsed"]
+t_trtf <- system.time({
+  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)
+  trtf_ll <- logL_TRTF_dim(M_TRTF, S$X_te)
+})[["elapsed"]]
 
-baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
-trtf_ll     <- logL_TRTF_dim(M_TRTF, S$X_te)
-ks_ll       <- logL_KS_dim(M_KS, S$X_te)
-ttm_ll      <- logL_TTM_dim(M_TTM, S$X_te)
+t_ks <- system.time({
+  M_KS <- fit_KS(S$X_tr, S$X_te, G$config)
+  ks_ll <- logL_KS_dim(M_KS, S$X_te)
+})[["elapsed"]]
+
+t_ttm <- system.time({
+  M_TTM <- fit_TTM(S$X_tr, S$X_te)
+  ttm_ll <- logL_TTM_dim(M_TTM, S$X_te)
+})[["elapsed"]]
 
 tab_normal <- data.frame(
   dim = as.character(seq_along(G$config)),
@@ -56,15 +61,25 @@ X_te_p <- S$X_te[, c(2,1,3,4)[seq_len(ncol(S$X_te))], drop = FALSE]
 colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
 colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
 
-M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
-M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
-M_KS_p   <- fit_KS(X_tr_p, X_te_p, G$config)
-M_TTM_p  <- fit_TTM(X_tr_p, X_te_p)
+t_true_p <- system.time({
+  M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
+  baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
+})[["elapsed"]]
 
-baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
-trtf_ll_p     <- logL_TRTF_dim(M_TRTF_p, X_te_p)
-ks_ll_p       <- logL_KS_dim(M_KS_p, X_te_p)
-ttm_ll_p      <- logL_TTM_dim(M_TTM_p, X_te_p)
+t_trtf_p <- system.time({
+  M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
+  trtf_ll_p <- logL_TRTF_dim(M_TRTF_p, X_te_p)
+})[["elapsed"]]
+
+t_ks_p <- system.time({
+  M_KS_p <- fit_KS(X_tr_p, X_te_p, G$config)
+  ks_ll_p <- logL_KS_dim(M_KS_p, X_te_p)
+})[["elapsed"]]
+
+t_ttm_p <- system.time({
+  M_TTM_p <- fit_TTM(X_tr_p, X_te_p)
+  ttm_ll_p <- logL_TTM_dim(M_TTM_p, X_te_p)
+})[["elapsed"]]
 
 tab_perm <- data.frame(
   dim = as.character(seq_along(G$config)),
@@ -89,10 +104,10 @@ for (nm in names(tab_perm)) {
 tab_perm <- rbind(tab_perm, as.data.frame(sum_row, stringsAsFactors = FALSE))
 
 vec_normal <- c(true = t_true, trtf = t_trtf, ks = t_ks, ttm = t_ttm)
+vec_perm   <- c(true = t_true_p, trtf = t_trtf_p, ks = t_ks_p, ttm = t_ttm_p)
 
 kbl_obj <- combine_logL_tables(tab_normal, tab_perm,
-                              M_TRUE_p, M_TRTF_p, M_KS_p, M_TTM_p, X_te_p,
-                              vec_normal)
+                              vec_normal, vec_perm)
 
 setwd(old_wd)
 


### PR DESCRIPTION
## Summary
- adapt combine_logL_tables() to accept runtimes for permutation order
- measure total runtime (fit + evaluation) for all models in `main()`
- adjust unit test to new runtime logic

## Testing
- `lintr::lint_dir()` *(fails: object_name_linter warnings)*
- `testthat::test_dir('tests/testthat')` *(failed to complete due to package installation limits)*

------
https://chatgpt.com/codex/tasks/task_e_6844a8f7c6088333907d7dc549cde432