### PR TITLE
Tabellen im Terminal ausgeben

### DIFF
--- a/EDA.R
+++ b/EDA.R
@@ -47,11 +47,7 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
       tab_data[-nrow(tab_data), col] <- sprintf("%.3f", as.numeric(tab_data[-nrow(tab_data), col]))
       tab_data[nrow(tab_data), col]  <- sprintf("%.0f", last_val)
     }
-    tbl <- gridExtra::tableGrob(
-      tab_data, rows = NULL,
-      theme = gridExtra::ttheme_default(base_size = 9)
-    )
-    gridExtra::grid.arrange(tbl, top = "Average -logLikelihood")
+    print(tab_data)
   }
   if (!is.null(plots))
     gridExtra::grid.arrange(grobs = plots, ncol = 2)

--- a/tests/testthat/test_EDA.R
+++ b/tests/testthat/test_EDA.R
@@ -16,4 +16,16 @@ test_that("create_EDA_report produces pdf", {
   unlink(res)
 })
 
+test_that("create_EDA_report prints table", {
+  pdf_file <- tempfile(fileext = ".pdf")
+  df <- data.frame(dim = "1", distr = "gauss", val = 0.5)
+  kbl_obj <- knitr::kable(df)
+  attr(kbl_obj, "tab_data") <- df
+  out <- capture.output(res <- create_EDA_report(X, G$config, pdf_file,
+                                                table_kbl = kbl_obj))
+  expect_true(any(grepl("dim", out)))
+  expect_true(file.exists(res))
+  unlink(res)
+})
+
 setwd(old_wd)


### PR DESCRIPTION
## Summary
- Tabelle aus `create_EDA_report` nicht mehr ins PDF rendern
- Ausgabe der Tabelle jetzt direkt im Terminal
- neuen Test ergänzt, der die Terminalausgabe prüft

## Testing
- `R -q -e "lintr::lint_dir()"`
- `Rscript tests/testthat.R` *(scheiterte: Error in `full_res$normal` …)*

------
https://chatgpt.com/codex/tasks/task_e_6844bfb9ce0883339fb65176e269f28c