### PR TITLE
update default sample size

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -19,7 +19,7 @@ softplus <- function(x) log1p(exp(x))
 #' @return list with elements `n`, `config`, `seed`, `split_ratio`,
 #'   `h_grid`, `model_ids` and `p_max`
 setup_global <- function(cfg = config) {
-  n <- 500
+  n <- 50
   seed <- 42
   split_ratio <- 0.5
   p_max <- 6

--- a/tests/testthat/test_globals.R
+++ b/tests/testthat/test_globals.R
@@ -1,7 +1,7 @@
 test_that("setup_global returns expected list", {
   out <- setup_global()
   expect_type(out, "list")
-  expect_equal(out$n, 500)
+  expect_equal(out$n, 50)
   expect_equal(length(out$config), length(config))
   expect_equal(vapply(out$config, `[[`, "distr", FUN.VALUE = ""),
                vapply(config, `[[`, "distr", FUN.VALUE = ""))


### PR DESCRIPTION
## Summary
- reduce default `n` to 50 in `setup_global`
- adjust corresponding expectation in `test_globals`

## Testing
- `Rscript -e 'lintr::lint_dir()'`
- `Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_68459236764c8333a166741110c8e599