### PR TITLE
Runtime-Metrik nur noch für Vorhersage

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -67,9 +67,9 @@ add_sum_row <- function(tab, label = "k") {
 #'
 #' @param tab_normal table created in `main()` using the original order
 #' @param tab_perm   table created in `main()` on permuted variables
-#' @param t_normal named numeric vector with runtimes in normal order
+#' @param t_normal named numeric vector with **prediction** runtimes in normal order
 #'                 (names: true, trtf, ks)
-#' @param t_perm   named numeric vector with runtimes in permutation order
+#' @param t_perm   named numeric vector with **prediction** runtimes in permutation order
 #'                 (names: true, trtf, ks)
 #' @return `kableExtra` table with average log-likelihoods and runtimes
 #' @export
@@ -102,6 +102,7 @@ combine_logL_tables <- function(tab_normal, tab_perm,
   tab_all <- tab_all %>%
     rename_with(~ sub("_norm$", "", .x), ends_with("_norm"))
 
+  # prediction runtime in milliseconds
   tab_all <- tab_all %>%
       add_row(
         dim       = "runtime (ms)",

--- a/main.R
+++ b/main.R
@@ -32,19 +32,19 @@ main <- function() {
   param_list <- X_dat$params
   S <- train_test_split(X, G$split_ratio, G$seed) # Script 3
 
-  ## Modelle in Originalreihenfolge inklusive Laufzeitmessung
+  ## Modelle in Originalreihenfolge
+  M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)    # Script 5
   t_true <- system.time({
-    M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)    # Script 5
     baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
   })[["elapsed"]]
 
+  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)    # Script models/trtf_model.R
   t_trtf <- system.time({
-    M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)    # Script models/trtf_model.R
     trtf_ll <- logL_TRTF_dim(M_TRTF, S$X_te)
   })[["elapsed"]]
 
+  M_KS <- fit_KS(S$X_tr, S$X_te, G$config)        # Script models/ks_model.R
   t_ks <- system.time({
-    M_KS <- fit_KS(S$X_tr, S$X_te, G$config)        # Script models/ks_model.R
     ks_ll <- logL_KS_dim(M_KS, S$X_te)
   })[["elapsed"]]
 
@@ -66,18 +66,18 @@ main <- function() {
   colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
   colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
 
+  M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
   t_true_p <- system.time({
-    M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
     baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
   })[["elapsed"]]
 
+  M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
   t_trtf_p <- system.time({
-    M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
     trtf_ll_p <- logL_TRTF_dim(M_TRTF_p, X_te_p)
   })[["elapsed"]]
 
+  M_KS_p <- fit_KS(X_tr_p, X_te_p, G$config)
   t_ks_p <- system.time({
-    M_KS_p <- fit_KS(X_tr_p, X_te_p, G$config)
     ks_ll_p <- logL_KS_dim(M_KS_p, X_te_p)
   })[["elapsed"]]
 

--- a/tests/testthat/test_combine_tables.R
+++ b/tests/testthat/test_combine_tables.R
@@ -13,18 +13,18 @@ G$n <- 10
 X <- gen_samples(G)
 S <- train_test_split(X, G$split_ratio, G$seed)
 
+M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)
 t_true <- system.time({
-  M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)
   baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
 })[["elapsed"]]
 
+M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)
 t_trtf <- system.time({
-  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)
   trtf_ll <- logL_TRTF_dim(M_TRTF, S$X_te)
 })[["elapsed"]]
 
+M_KS <- fit_KS(S$X_tr, S$X_te, G$config)
 t_ks <- system.time({
-  M_KS <- fit_KS(S$X_tr, S$X_te, G$config)
   ks_ll <- logL_KS_dim(M_KS, S$X_te)
 })[["elapsed"]]
 
@@ -55,18 +55,18 @@ X_te_p <- S$X_te[, c(2,1,3,4)[seq_len(ncol(S$X_te))], drop = FALSE]
 colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
 colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
 
+M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
 t_true_p <- system.time({
-  M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
   baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
 })[["elapsed"]]
 
+M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
 t_trtf_p <- system.time({
-  M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
   trtf_ll_p <- logL_TRTF_dim(M_TRTF_p, X_te_p)
 })[["elapsed"]]
 
+M_KS_p <- fit_KS(X_tr_p, X_te_p, G$config)
 t_ks_p <- system.time({
-  M_KS_p <- fit_KS(X_tr_p, X_te_p, G$config)
   ks_ll_p <- logL_KS_dim(M_KS_p, X_te_p)
 })[["elapsed"]]
 


### PR DESCRIPTION
## Summary
- korrigiere Messung der Laufzeit in `main.R` auf reine Vorhersage
- passe entsprechende Unit-Tests an
- dokumentiere im Evaluationsskript, dass nur Vorhersage gemessen wird

## Testing
- `Rscript tests/testthat.R` *(bricht wegen langer Laufzeit ab, Tabelle wird jedoch erzeugt)*
- `Rscript -e 'lintr::lint_dir()'`

------
https://chatgpt.com/codex/tasks/task_e_684595fbecb48333ac5380720d031b4a