### PR TITLE
Remove PDF output from EDA report

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -259,8 +259,9 @@ function combine_logL_tables(tab_normal, tab_perm, t_normal, t_perm)
 
 ### create_EDA_report
 `create_EDA_report(X, cfg, output_file, scatter_data, table_kbl, param_list)`
-- **Description:** generate PDF with histograms and scatter plots comparing true vs. estimated log-densities.
-- **Pre/Post:** purely side effects; no returned values of interest.
+- **Description:** erzeugt Histogramme und Streuplots der Log-Dichten und gibt
+  eine Liste mit `plots`, `param_plots` und `table` zurueck.
+- **Pre/Post:** keine Seiteneffekte auf Dateien.
 
 ## 4. Randomness & Reproducibility
 Each module drawing random numbers sets the RNG via `set.seed` with an integer seed. Seeds are derived from the global seed (`G.seed`) with deterministic offsets. Random variables are sampled from base R distributions (`rnorm`, `rexp`, `rbeta`, `rgamma`) or via transformation forests and kernel smoothing. All optimization routines are deterministic given these seeds. To reproduce results, record `G.seed` and any hyperparameter grid.

--- a/EDA.R
+++ b/EDA.R
@@ -1,12 +1,12 @@
 #' Exploratory Data Analysis for Generated Samples
 #'
-#' Creates tables and scatter plots comparing estimated log-densities with
-#' the wahren Werten. Results are written to a PDF.
+#' Creates tables and Scatter-Plots der geschaetzten gegen die wahren
+#' Log-Dichten.  Gibt Plots und Tabellen als Liste zurueck.
 #'
 #' @param X matrix of generated samples
 #' @param cfg configuration list as in `gen_samples`
-#' @param output_file path to PDF file
-#' @return invisibly the path to the created PDF
+#' @param output_file bislang Pfad zu einer PDF-Datei (wird ignoriert)
+#' @return Liste mit Elementen `plots`, `param_plots` und `table`
 
 create_param_plots <- function(param_list) {
   plots <- list()
@@ -58,7 +58,6 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
   if (!is.null(param_list))
     param_plots <- create_param_plots(param_list)
 
-  pdf(output_file, width = 8, height = 11, title = "Average logL")
   if (!is.null(table_kbl)) {
     tab_data <- attr(table_kbl, "tab_data")
     num_cols <- vapply(tab_data, is.numeric, logical(1))
@@ -67,16 +66,14 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
       tab_data[-nrow(tab_data), col] <- sprintf("%.3f", as.numeric(tab_data[-nrow(tab_data), col]))
       tab_data[nrow(tab_data), col]  <- sprintf("%.0f", last_val)
     }
-    print(tab_data)
   }
   if (!is.null(plots))
     gridExtra::grid.arrange(grobs = plots, ncol = 2)
   if (!is.null(param_plots)) {
     for (pg in param_plots)
-      print(pg)
+      gridExtra::grid.arrange(pg)
   }
-  dev.off()
-  invisible(output_file)
+  list(plots = plots, param_plots = param_plots, table = table_kbl)
 }
 
 #' VollstÃ¤ndigen Analyseablauf ausfÃ¼hren

--- a/tests/testthat/test_EDA.R
+++ b/tests/testthat/test_EDA.R
@@ -9,23 +9,35 @@ G$n <- 10
 X <- gen_samples(G)
 
 
-test_that("create_EDA_report produces pdf", {
-  pdf_file <- tempfile(fileext = ".pdf")
-  res <- create_EDA_report(X, G$config, pdf_file)
-  expect_true(file.exists(res))
-  unlink(res)
+test_that("create_EDA_report liefert Plot-Objekte", {
+  scat <- list(
+    ld_base = rnorm(5),
+    ld_trtf = rnorm(5),
+    ld_ks = rnorm(5),
+    ld_base_p = rnorm(5),
+    ld_trtf_p = rnorm(5),
+    ld_ks_p = rnorm(5)
+  )
+  res <- create_EDA_report(X, G$config, scatter_data = scat)
+  expect_type(res, "list")
+  expect_true(is.list(res$plots))
+  expect_s3_class(res$plots[[1]], "ggplot")
 })
 
-test_that("create_EDA_report prints table", {
-  pdf_file <- tempfile(fileext = ".pdf")
+test_that("create_EDA_report gibt Tabelle zurueck", {
   df <- data.frame(dim = "1", distr = "gauss", val = 0.5)
   kbl_obj <- knitr::kable(df)
   attr(kbl_obj, "tab_data") <- df
-  out <- capture.output(res <- create_EDA_report(X, G$config, pdf_file,
-                                                table_kbl = kbl_obj))
-  expect_true(any(grepl("dim", out)))
-  expect_true(file.exists(res))
-  unlink(res)
+  res <- create_EDA_report(X, G$config, table_kbl = kbl_obj)
+  expect_s3_class(res$table, "knitr_kable")
+  expect_identical(attr(res$table, "tab_data"), df)
+})
+
+test_that("create_EDA_report erstellt Parameterhistogramme", {
+  Xdat <- gen_samples(G, return_params = TRUE)
+  res <- create_EDA_report(Xdat$X, G$config, param_list = Xdat$params)
+  expect_true(length(res$param_plots) > 0)
+  expect_s3_class(res$param_plots[[1]], "ggplot")
 })
 
 setwd(old_wd)


### PR DESCRIPTION
## Summary
- remove pdf() calls and printing in `create_EDA_report`
- return list of plots, parameter plots and tables
- adjust specification in `ALGORITHM_SPEC.md`
- update tests for new return values

## Testing
- `lintr::lint_dir(".")`
- `testthat::test_dir("tests/testthat", reporter="summary")`


------
https://chatgpt.com/codex/tasks/task_e_685a704b6028833382324f1bd6cad73c