### PR TITLE
Doku an neue EDA-Struktur angepasst

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -27,7 +27,8 @@ where
 6. $f_6 = \texttt{logL\_\*\_dim}$ – compute dimension-wise log-likelihoods.
 7. $f_7 = \texttt{add\_sum\_row}$ – append totals to tables.
 8. $f_8 = \texttt{combine\_logL\_tables}$ – assemble final evaluation table.
-Additional reporting is produced via `create_EDA_report` (plots/tables).
+Reporting geschieht über `create_EDA_report` und wird mittels eines
+RMarkdown-Templates gerendert.
 
 ## 3. Module Specifications
 ### setup_global
@@ -259,8 +260,17 @@ function combine_logL_tables(tab_normal, tab_perm, t_normal, t_perm)
 
 ### create_EDA_report
 `create_EDA_report(X, cfg, output_file, scatter_data, table_kbl, param_list)`
-- **Description:** generate PDF with histograms and scatter plots comparing true vs. estimated log-densities.
-- **Pre/Post:** purely side effects; no returned values of interest.
+- **Description:** erstellt Plots und Tabellen der explorativen Analyse und rendert sie 
+  mittels des RMarkdown-Templates.
+- **Pre/Post:** rein durch Seiteneffekte; kein Rückgabewert von Interesse.
+
+### create_param_plots
+`create_param_plots(param_list) : list \to list(plot)`
+- **Description:** erzeugt Histogramme zu geschätzten Parametern zur Verwendung in `create_EDA_report`.
+
+### run_pipeline
+`run_pipeline(n, config, perm) : (integer, list, integer vector) \to kable`
+- **Description:** führt den kompletten Workflow aus Daten- und Modellgenerierung aus und nutzt `create_EDA_report` zur Berichtserstellung.
 
 ## 4. Randomness & Reproducibility
 Each module drawing random numbers sets the RNG via `set.seed` with an integer seed. Seeds are derived from the global seed (`G.seed`) with deterministic offsets. Random variables are sampled from base R distributions (`rnorm`, `rexp`, `rbeta`, `rgamma`) or via transformation forests and kernel smoothing. All optimization routines are deterministic given these seeds. To reproduce results, record `G.seed` and any hyperparameter grid.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ scale.
 ## Configuration Syntax
 
 The configuration `config` is a list of length $K`.  Each entry has a field
-`distr` specifying the family.  
+`distr` specifying the family.
+
+## Explorative Datenanalyse
+
+Die Datei `EDA.R` stellt mit `run_pipeline()` und `create_EDA_report()` zwei
+modulare Funktionen bereit, die den gesamten Ablauf von der Datengenerierung bis
+zur Auswertung kapseln. Die resultierenden Tabellen und Plots werden über ein
+RMarkdown-Template (`docs/eda_template.Rmd`) gerendert und können anschließend
+nach HTML oder PDF exportiert werden.
 
 ## End_of_readme
 

--- a/docs/eda_template.Rmd
+++ b/docs/eda_template.Rmd
@@ -1,0 +1,12 @@
+---
+title: "EDA Report"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+# Platzhalter
+
+Dieser Bericht wird durch `create_EDA_report()` automatisch gefüllt.


### PR DESCRIPTION
## Zusammenfassung
- Hinweise zu `run_pipeline()` und `create_EDA_report()` in README
- PDF-Verweise in der Spezifikation angepasst
- neue Module `create_param_plots` und `run_pipeline` dokumentiert
- RMarkdown-Template für Berichte ergänzt

## Testing
- Keine Tests erforderlich, da nur Dokumentation geändert wurde

------
https://chatgpt.com/codex/tasks/task_e_685a704f69848333a4730ed94798d001