### PR TITLE
Implement modular pipeline helpers

### DIFF
--- a/EDA.R
+++ b/EDA.R
@@ -76,6 +76,129 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
   list(plots = plots, param_plots = param_plots, table = table_kbl)
 }
 
+#' Daten vorbereiten
+#'
+#' Generiert Stichproben gemäß `config`, splittet sie in Trainings-
+#' und Testdaten und legt eine permutierte Variante an.
+#'
+#' @param n Stichprobengröße
+#' @param config Konfigurationsliste
+#' @param perm Permutationsvektor
+#' @return Liste mit Trainings- und Testdaten sowie Parameterhistorie
+prepare_data <- function(n, config, perm) {
+  G <- list(n = n, config = config, seed = 42, split_ratio = 0.5)
+  X_dat <- gen_samples(G, return_params = TRUE)
+  S <- train_test_split(X_dat$X, G$split_ratio, G$seed)
+  X_tr_p <- S$X_tr[, perm, drop = FALSE]
+  X_te_p <- S$X_te[, perm, drop = FALSE]
+  colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
+  colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
+  list(X_tr = S$X_tr, X_te = S$X_te,
+       X_tr_p = X_tr_p, X_te_p = X_te_p,
+       param_list = X_dat$params, config = config)
+}
+
+#' Modelle fitten und Laufzeiten messen
+#'
+#' Passt TRUE, TRTF und KS an normale und permutierte Daten an.
+#'
+#' @param S Liste aus `prepare_data`
+#' @param config Konfigurationsliste
+#' @return Liste mit Modellen und Laufzeiten
+fit_models <- function(S, config) {
+  M_TRUE <- fit_TRUE(S$X_tr, S$X_te, config)
+  t_true <- system.time({ logL_TRUE_dim(M_TRUE, S$X_te) })[["elapsed"]]
+  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, config)
+  t_trtf <- system.time({ logL_TRTF_dim(M_TRTF, S$X_te) })[["elapsed"]]
+  M_KS <- fit_KS(S$X_tr, S$X_te, config)
+  t_ks <- system.time({ logL_KS_dim(M_KS, S$X_te) })[["elapsed"]]
+
+  M_TRUE_p <- fit_TRUE(S$X_tr_p, S$X_te_p, config)
+  t_true_p <- system.time({ logL_TRUE_dim(M_TRUE_p, S$X_te_p) })[["elapsed"]]
+  M_TRTF_p <- fit_TRTF(S$X_tr_p, S$X_te_p, config)
+  t_trtf_p <- system.time({ logL_TRTF_dim(M_TRTF_p, S$X_te_p) })[["elapsed"]]
+  M_KS_p <- fit_KS(S$X_tr_p, S$X_te_p, config)
+  t_ks_p <- system.time({ logL_KS_dim(M_KS_p, S$X_te_p) })[["elapsed"]]
+
+  list(
+    normal = list(true = M_TRUE, trtf = M_TRTF, ks = M_KS),
+    perm   = list(true = M_TRUE_p, trtf = M_TRTF_p, ks = M_KS_p),
+    runtime_normal = c(true = t_true, trtf = t_trtf, ks = t_ks),
+    runtime_perm   = c(true = t_true_p, trtf = t_trtf_p, ks = t_ks_p)
+  )
+}
+
+#' Log-Likelihood-Tabellen berechnen
+#'
+#' Erstellt Tabellen für originale und permutierte Reihenfolge.
+#'
+#' @param models Ergebnis von `fit_models`
+#' @param S Liste aus `prepare_data`
+#' @return Liste mit Tabellen `tab_normal` und `tab_perm`
+calc_loglik_tables <- function(models, S) {
+  cfg <- S$config
+  baseline_ll <- logL_TRUE_dim(models$normal$true, S$X_te)
+  trtf_ll <- logL_TRTF_dim(models$normal$trtf, S$X_te)
+  ks_ll <- logL_KS_dim(models$normal$ks, S$X_te)
+
+  tab_normal <- data.frame(
+    dim = as.character(seq_along(cfg)),
+    distribution = sapply(cfg, `[[`, "distr"),
+    logL_baseline = baseline_ll,
+    logL_trtf = trtf_ll,
+    logL_ks = ks_ll,
+    stringsAsFactors = FALSE
+  )
+  tab_normal <- add_sum_row(tab_normal)
+
+  baseline_ll_p <- logL_TRUE_dim(models$perm$true, S$X_te_p)
+  trtf_ll_p <- logL_TRTF_dim(models$perm$trtf, S$X_te_p)
+  ks_ll_p <- logL_KS_dim(models$perm$ks, S$X_te_p)
+
+  tab_perm <- data.frame(
+    dim = as.character(seq_along(cfg)),
+    distribution = sapply(cfg, `[[`, "distr"),
+    logL_baseline = baseline_ll_p,
+    logL_trtf = trtf_ll_p,
+    logL_ks = ks_ll_p,
+    stringsAsFactors = FALSE
+  )
+  tab_perm <- add_sum_row(tab_perm)
+
+  list(tab_normal = tab_normal, tab_perm = tab_perm)
+}
+
+#' Daten für Scatterplots zusammenstellen
+#'
+#' Gibt die wahren und geschätzten Log-Dichten zurück.
+#'
+#' @param models Ergebnis von `fit_models`
+#' @param S Liste aus `prepare_data`
+#' @return Liste mit logDichte-Vektoren
+make_scatter_data <- function(models, S) {
+  cfg <- S$config
+  ld_base <- rowSums(vapply(seq_along(cfg), function(k) {
+    .log_density_vec(S$X_te[, k], cfg[[k]]$distr,
+                     models$normal$true$theta[[k]])
+  }, numeric(nrow(S$X_te))))
+  ld_trtf <- as.numeric(predict(models$normal$trtf, S$X_te,
+                                type = "logdensity"))
+  ld_ks <- as.numeric(predict(models$normal$ks, S$X_te,
+                              type = "logdensity"))
+
+  ld_base_p <- rowSums(vapply(seq_along(cfg), function(k) {
+    .log_density_vec(S$X_te_p[, k], cfg[[k]]$distr,
+                     models$perm$true$theta[[k]])
+  }, numeric(nrow(S$X_te_p))))
+  ld_trtf_p <- as.numeric(predict(models$perm$trtf, S$X_te_p,
+                                  type = "logdensity"))
+  ld_ks_p <- as.numeric(predict(models$perm$ks, S$X_te_p,
+                                type = "logdensity"))
+
+  list(ld_base = ld_base, ld_trtf = ld_trtf, ld_ks = ld_ks,
+       ld_base_p = ld_base_p, ld_trtf_p = ld_trtf_p, ld_ks_p = ld_ks_p)
+}
+
 #' VollstÃ¤ndigen Analyseablauf ausfÃ¼hren
 #'
 #' Diese Funktion Ã¼bernimmt die Hauptlogik aus `main()` und erzeugt sowohl
@@ -85,120 +208,22 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
 #' @param n      StichprobengrÃ¶Ãe
 #' @param config Listenkonfiguration der Zielverteilungen
 #' @param perm   Permutationsvektor der Spalten
-#' @return `knitr_kable`-Objekt mit zusammengefassten Log-Likelihoods
+#' @return Liste der Einzelergebnisse
 #' @export
 run_pipeline <- function(n, config, perm) {
-  t0 <- proc.time()
+  dat <- prepare_data(n, config, perm)
+  models <- fit_models(dat, config)
+  tables <- calc_loglik_tables(models, dat)
+  scatter <- make_scatter_data(models, dat)
+  kbl_tab <- combine_logL_tables(tables$tab_normal, tables$tab_perm,
+                                 models$runtime_normal, models$runtime_perm)
 
-  G <- list(
-    n = n,
-    config = config,
-    seed = 42,
-    split_ratio = 0.5
-  )
-
-  X_dat <- gen_samples(G, return_params = TRUE)
-  X <- X_dat$X
-  param_list <- X_dat$params
-  S <- train_test_split(X, G$split_ratio, G$seed)
-
-  M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)
-  t_true <- system.time({
-    baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
-  })[["elapsed"]]
-
-  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)
-  t_trtf <- system.time({
-    trtf_ll <- logL_TRTF_dim(M_TRTF, S$X_te)
-  })[["elapsed"]]
-
-  M_KS <- fit_KS(S$X_tr, S$X_te, G$config)
-  t_ks <- system.time({
-    ks_ll <- logL_KS_dim(M_KS, S$X_te)
-  })[["elapsed"]]
-
-  tab_normal <- data.frame(
-    dim = as.character(seq_along(G$config)),
-    distribution = sapply(G$config, `[[`, "distr"),
-    logL_baseline = baseline_ll,
-    logL_trtf = trtf_ll,
-    logL_ks = ks_ll,
-    stringsAsFactors = FALSE
-  )
-
-  tab_normal <- add_sum_row(tab_normal)
-
-  X_tr_p <- S$X_tr[, perm, drop = FALSE]
-  X_te_p <- S$X_te[, perm, drop = FALSE]
-  colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
-  colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
-
-  M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
-  t_true_p <- system.time({
-    baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
-  })[["elapsed"]]
-
-  M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
-  t_trtf_p <- system.time({
-    trtf_ll_p <- logL_TRTF_dim(M_TRTF_p, X_te_p)
-  })[["elapsed"]]
-
-  M_KS_p <- fit_KS(X_tr_p, X_te_p, G$config)
-  t_ks_p <- system.time({
-    ks_ll_p <- logL_KS_dim(M_KS_p, X_te_p)
-  })[["elapsed"]]
-
-  tab_perm <- data.frame(
-    dim = as.character(seq_along(G$config)),
-    distribution = sapply(G$config, `[[`, "distr"),
-    logL_baseline = baseline_ll_p,
-    logL_trtf = trtf_ll_p,
-    logL_ks = ks_ll_p,
-    stringsAsFactors = FALSE
-  )
-
-  tab_perm <- add_sum_row(tab_perm)
-
-  ld_base <- rowSums(vapply(seq_along(G$config), function(k) {
-    .log_density_vec(S$X_te[, k], G$config[[k]]$distr, M_TRUE$theta[[k]])
-  }, numeric(nrow(S$X_te))))
-  ld_trtf <- as.numeric(predict(M_TRTF, S$X_te, type = "logdensity"))
-  ld_ks   <- as.numeric(predict(M_KS, S$X_te, type = "logdensity"))
-
-  runtime <- round((proc.time() - t0)[["elapsed"]], 2)
-  message(paste0("Laufzeit: ", runtime, " Sekunden"))
-
-  ld_base_p <- rowSums(vapply(seq_along(G$config), function(k) {
-    .log_density_vec(X_te_p[, k], G$config[[k]]$distr, M_TRUE_p$theta[[k]])
-  }, numeric(nrow(X_te_p))))
-  ld_trtf_p <- as.numeric(predict(M_TRTF_p, X_te_p, type = "logdensity"))
-  ld_ks_p   <- as.numeric(predict(M_KS_p,   X_te_p, type = "logdensity"))
-
-  scatter_data <- list(
-    ld_base   = ld_base,
-    ld_trtf   = ld_trtf,
-    ld_ks     = ld_ks,
-    ld_base_p = ld_base_p,
-    ld_trtf_p = ld_trtf_p,
-    ld_ks_p   = ld_ks_p
-  )
-
-  vec_normal <- c(true = t_true, trtf = t_trtf, ks = t_ks)
-  vec_perm   <- c(true = t_true_p, trtf = t_trtf_p, ks = t_ks_p)
-  kbl_tab <- combine_logL_tables(tab_normal, tab_perm,
-                                 vec_normal, vec_perm)
-
-  create_EDA_report(S$X_tr, G$config,
-                    scatter_data = scatter_data,
+  create_EDA_report(dat$X_tr, config,
+                    scatter_data = scatter,
                     table_kbl = kbl_tab,
-                    param_list = param_list)
+                    param_list = dat$param_list)
 
-  message(paste0("N = ", G$n))
-  message("Beste Hyperparameter fuer TRTF:")
-  print(M_TRTF$best_cfg)
-  print(attr(kbl_tab, "tab_data"))
-
-  res <- kbl_tab
-  attr(res, "tab_data") <- attr(kbl_tab, "tab_data")
-  res
+  list(data = dat, models = models,
+       tables = tables, scatter = scatter,
+       kbl_tab = kbl_tab)
 }

--- a/main.R
+++ b/main.R
@@ -19,7 +19,7 @@ perm <- c(3, 4, 1, 2)
 #' Starte die komplette Analyse
 #'
 #' Diese Wrapper-Funktion ruft `run_pipeline()` aus `EDA.R` auf und gibt
-#' die erzeugte Ergebnistabelle zurück.
+#' die erzeugten Zwischenergebnisse zurück.
 #'
 #' @export
 main <- function() {

--- a/tests/testthat/test_baseline_limit.R
+++ b/tests/testthat/test_baseline_limit.R
@@ -4,7 +4,7 @@ source("main.R")
 set.seed(123)
 n <- 100
 res <- main()
-tab <- attr(res, "tab_data")
+tab <- attr(res$kbl_tab, "tab_data")
 setwd(old_wd)
 
 test_that("logL_baseline within +/-10 for N=100", {

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -17,9 +17,10 @@ n <- 20
 res <- main()
 setwd(old_wd)
 
-test_that("main outputs combined kable table", {
-  expect_s3_class(res, "knitr_kable")
-  tab_data <- attr(res, "tab_data")
+test_that("main gibt Ergebnisliste zurueck", {
+  expect_true(is.list(res))
+  expect_s3_class(res$kbl_tab, "knitr_kable")
+  tab_data <- attr(res$kbl_tab, "tab_data")
   expect_s3_class(tab_data, "data.frame")
   expect_true(all(is.finite(tab_data$true[1:length(G$config)])))
 })

--- a/tests/testthat/test_pipeline.R
+++ b/tests/testthat/test_pipeline.R
@@ -1,0 +1,48 @@
+old_wd <- setwd("../..")
+source("EDA.R")
+source("00_globals.R")
+source("01_data_generation.R")
+source("02_split.R")
+source("models/true_model.R")
+source("models/trtf_model.R")
+source("models/ks_model.R")
+
+set.seed(1)
+perm <- c(3,4,1,2)
+
+pd <- prepare_data(20, config, perm)
+models <- fit_models(pd, config)
+
+context("pipeline helpers")
+
+test_that("prepare_data erstellt korrekte Listen", {
+  expect_true(is.list(pd))
+  expect_true(is.matrix(pd$X_tr))
+  expect_equal(ncol(pd$X_tr_p), length(perm))
+  expect_identical(pd$X_te_p[,1], pd$X_te[,perm[1]])
+  expect_true(is.list(pd$param_list))
+})
+
+test_that("fit_models liefert Modelle und Laufzeiten", {
+  expect_true(is.list(models$normal))
+  expect_true(all(c("true","trtf","ks") %in% names(models$normal)))
+  expect_true(all(models$runtime_normal >= 0))
+})
+
+tbls <- calc_loglik_tables(models, pd)
+
+test_that("calc_loglik_tables gibt Tabellen zurueck", {
+  expect_s3_class(tbls$tab_normal, "data.frame")
+  expect_equal(nrow(tbls$tab_normal), length(config) + 1)
+  expect_true(all(is.finite(tbls$tab_normal$logL_trtf)))
+})
+
+scat <- make_scatter_data(models, pd)
+
+test_that("make_scatter_data produziert numerische Vektoren", {
+  expect_true(is.numeric(scat$ld_trtf))
+  expect_length(scat$ld_trtf, nrow(pd$X_te))
+  expect_true(!anyNA(scat$ld_ks_p))
+})
+
+setwd(old_wd)


### PR DESCRIPTION
## Summary
- add `prepare_data`, `fit_models`, `calc_loglik_tables` and `make_scatter_data`
- refactor `run_pipeline` to use these helpers
- adjust `main` wrapper
- extend tests for new helpers and adapt existing ones

## Testing
- `Rscript -e lintr::lint_dir()`
- `Rscript -e "testthat::test_dir('tests/testthat', reporter='summary')"`

------
https://chatgpt.com/codex/tasks/task_e_685a73dd8dec8333a5670129ffff79a8