### PR TITLE
Überreste von gelöschten Tests entfernen

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -3,7 +3,7 @@
 
 ## Bibliotheken -------------------------------------------------------------
 pkgs <- c("trtf", "ggplot2", "gridExtra", "kableExtra", "dplyr",
-          "tibble", "testthat", "tidyr")
+          "tibble", "tidyr")
 for (p in pkgs) {
   if (!requireNamespace(p, quietly = TRUE))
     install.packages(p, repos = "https://cloud.r-project.org")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,0 @@
-source("00_globals.R")
-
-test_dir("tests/testthat")


### PR DESCRIPTION
## Summary
- entferne `testthat`-Abhängigkeit aus `00_globals.R`
- entferne verwaiste Datei `tests/testthat.R`

## Testing
- `Rscript -e "lintr::lint_dir()"` (liefert nur Warnungen)
- `Rscript tests/testthat.R` *(schlägt fehl, da Datei fehlt)*

------
https://chatgpt.com/codex/tasks/task_e_685a77a807188333b438d675b1972777