### PR TITLE
Implement modular EDA helpers

### DIFF
--- a/EDA.R
+++ b/EDA.R
@@ -79,6 +79,91 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
   list(plots = plots, param_plots = param_plots, table = table_kbl)
 }
 
+#' Daten vorbereiten und in Trainings-/Testsets aufteilen
+#'
+#' @param n Stichprobengroesse
+#' @param config Listenkonfiguration
+#' @param perm Permutationsvektor
+#' @return Liste mit Elementen `G`, `S`, `S_perm` und `param_list`
+#' @export
+prepare_data <- function(n, config, perm) {
+  G <- list(n = n, config = config, seed = 42, split_ratio = 0.5)
+  X_dat <- gen_samples(G, return_params = TRUE)
+  S <- train_test_split(X_dat$X, G$split_ratio, G$seed)
+
+  X_tr_p <- S$X_tr[, perm, drop = FALSE]
+  X_te_p <- S$X_te[, perm, drop = FALSE]
+  colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
+  colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
+  S_perm <- list(X_tr = X_tr_p, X_te = X_te_p)
+
+  list(G = G, S = S, S_perm = S_perm, param_list = X_dat$params)
+}
+
+#' TRUE, TRTF und KS Modelle fitten
+#'
+#' @param S Liste mit `X_tr` und `X_te`
+#' @param config Konfiguration der Zielverteilungen
+#' @return Liste `models`, `ll` und `times`
+#' @export
+fit_models <- function(S, config) {
+  M_TRUE <- fit_TRUE(S$X_tr, S$X_te, config)
+  t_true <- system.time({
+    ll_true <- logL_TRUE_dim(M_TRUE, S$X_te)
+  })[["elapsed"]]
+
+  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, config)
+  t_trtf <- system.time({
+    ll_trtf <- logL_TRTF_dim(M_TRTF, S$X_te)
+  })[["elapsed"]]
+
+  M_KS <- fit_KS(S$X_tr, S$X_te, config)
+  t_ks <- system.time({
+    ll_ks <- logL_KS_dim(M_KS, S$X_te)
+  })[["elapsed"]]
+
+  list(models = list(true = M_TRUE, trtf = M_TRTF, ks = M_KS),
+       ll = list(true = ll_true, trtf = ll_trtf, ks = ll_ks),
+       times = c(true = t_true, trtf = t_trtf, ks = t_ks))
+}
+
+#' Log-Likelihood-Tabellen erzeugen
+#'
+#' @param models Rueckgabe von `fit_models`
+#' @param config Konfiguration
+#' @return Datenrahmen mit Summenzeile
+#' @export
+calc_loglik_tables <- function(models, config) {
+  tab <- data.frame(
+    dim = as.character(seq_along(config)),
+    distribution = sapply(config, `[[`, "distr"),
+    logL_baseline = models$ll$true,
+    logL_trtf = models$ll$trtf,
+    logL_ks = models$ll$ks,
+    stringsAsFactors = FALSE
+  )
+  add_sum_row(tab)
+}
+
+#' Daten fuer Scatter-Plots erzeugen
+#'
+#' @param models Rueckgabe von `fit_models`
+#' @param S Liste mit `X_te`
+#' @return Liste mit Logdichte-Vektoren
+#' @export
+make_scatter_data <- function(models, S) {
+  G_cfg <- models$models$true$config
+  ld_base <- rowSums(vapply(seq_along(G_cfg), function(k) {
+    .log_density_vec(S$X_te[, k], G_cfg[[k]]$distr,
+                     models$models$true$theta[[k]])
+  }, numeric(nrow(S$X_te))))
+  ld_trtf <- as.numeric(predict(models$models$trtf, S$X_te,
+                                type = "logdensity"))
+  ld_ks <- as.numeric(predict(models$models$ks, S$X_te,
+                              type = "logdensity"))
+  list(ld_base = ld_base, ld_trtf = ld_trtf, ld_ks = ld_ks)
+}
+
 #' VollstÃ¤ndigen Analyseablauf ausfÃ¼hren
 #'
 #' Diese Funktion Ã¼bernimmt die Hauptlogik aus `main()` und erzeugt sowohl
@@ -88,120 +173,40 @@ create_EDA_report <- function(X, cfg, output_file = "eda_report.pdf",
 #' @param n      StichprobengrÃ¶Ãe
 #' @param config Listenkonfiguration der Zielverteilungen
 #' @param perm   Permutationsvektor der Spalten
-#' @return `knitr_kable`-Objekt mit zusammengefassten Log-Likelihoods
+#' @return Liste mit Daten, Modellen, Tabellen und Streudaten
 #' @export
 run_pipeline <- function(n, config, perm) {
   t0 <- proc.time()
+  prep <- prepare_data(n, config, perm)
 
-  G <- list(
-    n = n,
-    config = config,
-    seed = 42,
-    split_ratio = 0.5
-  )
+  mods_norm <- fit_models(prep$S, config)
+  tab_normal <- calc_loglik_tables(mods_norm, config)
+  scat_norm <- make_scatter_data(mods_norm, prep$S)
 
-  X_dat <- gen_samples(G, return_params = TRUE)
-  X <- X_dat$X
-  param_list <- X_dat$params
-  S <- train_test_split(X, G$split_ratio, G$seed)
+  mods_perm <- fit_models(prep$S_perm, config)
+  tab_perm <- calc_loglik_tables(mods_perm, config)
+  scat_perm <- make_scatter_data(mods_perm, prep$S_perm)
 
-  M_TRUE <- fit_TRUE(S$X_tr, S$X_te, G$config)
-  t_true <- system.time({
-    baseline_ll <- logL_TRUE_dim(M_TRUE, S$X_te)
-  })[["elapsed"]]
+  scatter_data <- c(scat_norm,
+                    setNames(scat_perm, paste0(names(scat_perm), "_p")))
 
-  M_TRTF <- fit_TRTF(S$X_tr, S$X_te, G$config)
-  t_trtf <- system.time({
-    trtf_ll <- logL_TRTF_dim(M_TRTF, S$X_te)
-  })[["elapsed"]]
+  kbl_tab <- combine_logL_tables(tab_normal, tab_perm,
+                                 mods_norm$times, mods_perm$times)
 
-  M_KS <- fit_KS(S$X_tr, S$X_te, G$config)
-  t_ks <- system.time({
-    ks_ll <- logL_KS_dim(M_KS, S$X_te)
-  })[["elapsed"]]
-
-  tab_normal <- data.frame(
-    dim = as.character(seq_along(G$config)),
-    distribution = sapply(G$config, `[[`, "distr"),
-    logL_baseline = baseline_ll,
-    logL_trtf = trtf_ll,
-    logL_ks = ks_ll,
-    stringsAsFactors = FALSE
-  )
-
-  tab_normal <- add_sum_row(tab_normal)
-
-  X_tr_p <- S$X_tr[, perm, drop = FALSE]
-  X_te_p <- S$X_te[, perm, drop = FALSE]
-  colnames(X_tr_p) <- paste0("X", seq_len(ncol(X_tr_p)))
-  colnames(X_te_p) <- paste0("X", seq_len(ncol(X_te_p)))
-
-  M_TRUE_p <- fit_TRUE(X_tr_p, X_te_p, G$config)
-  t_true_p <- system.time({
-    baseline_ll_p <- logL_TRUE_dim(M_TRUE_p, X_te_p)
-  })[["elapsed"]]
-
-  M_TRTF_p <- fit_TRTF(X_tr_p, X_te_p, G$config)
-  t_trtf_p <- system.time({
-    trtf_ll_p <- logL_TRTF_dim(M_TRTF_p, X_te_p)
-  })[["elapsed"]]
-
-  M_KS_p <- fit_KS(X_tr_p, X_te_p, G$config)
-  t_ks_p <- system.time({
-    ks_ll_p <- logL_KS_dim(M_KS_p, X_te_p)
-  })[["elapsed"]]
-
-  tab_perm <- data.frame(
-    dim = as.character(seq_along(G$config)),
-    distribution = sapply(G$config, `[[`, "distr"),
-    logL_baseline = baseline_ll_p,
-    logL_trtf = trtf_ll_p,
-    logL_ks = ks_ll_p,
-    stringsAsFactors = FALSE
-  )
-
-  tab_perm <- add_sum_row(tab_perm)
-
-  ld_base <- rowSums(vapply(seq_along(G$config), function(k) {
-    .log_density_vec(S$X_te[, k], G$config[[k]]$distr, M_TRUE$theta[[k]])
-  }, numeric(nrow(S$X_te))))
-  ld_trtf <- as.numeric(predict(M_TRTF, S$X_te, type = "logdensity"))
-  ld_ks   <- as.numeric(predict(M_KS, S$X_te, type = "logdensity"))
+  create_EDA_report(prep$S$X_tr, config,
+                    scatter_data = scatter_data,
+                    table_kbl = kbl_tab,
+                    param_list = prep$param_list)
 
   runtime <- round((proc.time() - t0)[["elapsed"]], 2)
   message(paste0("Laufzeit: ", runtime, " Sekunden"))
 
-  ld_base_p <- rowSums(vapply(seq_along(G$config), function(k) {
-    .log_density_vec(X_te_p[, k], G$config[[k]]$distr, M_TRUE_p$theta[[k]])
-  }, numeric(nrow(X_te_p))))
-  ld_trtf_p <- as.numeric(predict(M_TRTF_p, X_te_p, type = "logdensity"))
-  ld_ks_p   <- as.numeric(predict(M_KS_p,   X_te_p, type = "logdensity"))
-
-  scatter_data <- list(
-    ld_base   = ld_base,
-    ld_trtf   = ld_trtf,
-    ld_ks     = ld_ks,
-    ld_base_p = ld_base_p,
-    ld_trtf_p = ld_trtf_p,
-    ld_ks_p   = ld_ks_p
+  res <- list(
+    data = prep,
+    models = list(normal = mods_norm$models, perm = mods_perm$models),
+    tables = list(normal = tab_normal, perm = tab_perm, combined = kbl_tab),
+    scatter_data = scatter_data,
+    times = list(normal = mods_norm$times, perm = mods_perm$times)
   )
-
-  vec_normal <- c(true = t_true, trtf = t_trtf, ks = t_ks)
-  vec_perm   <- c(true = t_true_p, trtf = t_trtf_p, ks = t_ks_p)
-  kbl_tab <- combine_logL_tables(tab_normal, tab_perm,
-                                 vec_normal, vec_perm)
-
-  create_EDA_report(S$X_tr, G$config,
-                    scatter_data = scatter_data,
-                    table_kbl = kbl_tab,
-                    param_list = param_list)
-
-  message(paste0("N = ", G$n))
-  message("Beste Hyperparameter fuer TRTF:")
-  print(M_TRTF$best_cfg)
-  print(attr(kbl_tab, "tab_data"))
-
-  res <- kbl_tab
-  attr(res, "tab_data") <- attr(kbl_tab, "tab_data")
   res
 }

--- a/tests/testthat/test_baseline_limit.R
+++ b/tests/testthat/test_baseline_limit.R
@@ -4,7 +4,7 @@ source("main.R")
 set.seed(123)
 n <- 50
 res <- main()
-tab <- attr(res, "tab_data")
+tab <- attr(res$tables$combined, "tab_data")
 setwd(old_wd)
 
 test_that("logL_baseline within +/-10 for N=50", {

--- a/tests/testthat/test_calc_loglik_tables.R
+++ b/tests/testthat/test_calc_loglik_tables.R
@@ -1,0 +1,20 @@
+source("helper_config.R")
+source("../../EDA.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+
+set.seed(3)
+prep <- prepare_data(30, config, c(3,2,1,4))
+mods <- fit_models(prep$S, config)
+
+tab <- calc_loglik_tables(mods, config)
+
+test_that("calc_loglik_tables works", {
+  expect_true(is.data.frame(tab))
+  expect_equal(nrow(tab), length(config) + 1)
+  expect_true(all(is.finite(tab$logL_baseline)))
+  expect_true(all(is.finite(tab$logL_trtf)))
+  expect_true(all(is.finite(tab$logL_ks)))
+})

--- a/tests/testthat/test_fit_models2.R
+++ b/tests/testthat/test_fit_models2.R
@@ -1,0 +1,20 @@
+source("helper_config.R")
+source("../../EDA.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+
+set.seed(2)
+prep <- prepare_data(30, config, c(3,2,1,4))
+mods <- fit_models(prep$S, config)
+
+
+test_that("fit_models returns list of models", {
+  expect_true(is.list(mods$models))
+  expect_s3_class(mods$models$trtf, "mytrtf")
+  expect_true(is.list(mods$ll))
+  expect_length(mods$ll$true, length(config))
+  expect_true(all(is.finite(unlist(mods$ll))))
+  expect_true(all(mods$times >= 0))
+})

--- a/tests/testthat/test_make_scatter_data.R
+++ b/tests/testthat/test_make_scatter_data.R
@@ -1,0 +1,19 @@
+source("helper_config.R")
+source("../../EDA.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+
+set.seed(4)
+prep <- prepare_data(30, config, c(3,2,1,4))
+mods <- fit_models(prep$S, config)
+
+scat <- make_scatter_data(mods, prep$S)
+
+test_that("make_scatter_data returns numeric vectors", {
+  expect_true(is.list(scat))
+  expect_length(scat$ld_base, nrow(prep$S$X_te))
+  expect_true(all(is.finite(scat$ld_trtf)))
+  expect_true(all(is.finite(scat$ld_ks)))
+})

--- a/tests/testthat/test_prepare_data.R
+++ b/tests/testthat/test_prepare_data.R
@@ -1,0 +1,14 @@
+source("helper_config.R")
+source("../../EDA.R")
+
+set.seed(1)
+res <- prepare_data(20, config, c(3,2,1,4))
+
+
+test_that("prepare_data returns valid structure", {
+  expect_true(is.list(res))
+  expect_true(all(c("G", "S", "S_perm", "param_list") %in% names(res)))
+  expect_equal(nrow(res$S$X_tr) + nrow(res$S$X_te), 20)
+  expect_equal(ncol(res$S$X_tr), length(config))
+  expect_equal(ncol(res$S_perm$X_tr), length(config))
+})


### PR DESCRIPTION
## Summary
- restructure `run_pipeline` into helpers `prepare_data`, `fit_models`, `calc_loglik_tables` and `make_scatter_data`
- return a rich result list from `run_pipeline`
- adapt existing test and add unit tests for each new helper

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat", reporter="summary")'`
- `Rscript -e 'if(!requireNamespace("lintr",quietly=TRUE)) install.packages("lintr", repos="https://cloud.r-project.org"); lintr::lint_dir(".")'`


------
https://chatgpt.com/codex/tasks/task_e_685a79af912c8333bbe84636424bd16b