### PR TITLE
EDA und Pipeline modularisiert

### DIFF
--- a/tests/testthat/test_plot_functions.R
+++ b/tests/testthat/test_plot_functions.R
@@ -1,0 +1,29 @@
+source("helper_config.R")
+source("../../EDA.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+
+set.seed(5)
+prep <- prepare_data(20, config, c(3,2,1,4))
+mods_n <- fit_models(prep$S, config)
+mods_p <- fit_models(prep$S_perm, config)
+scat_n <- make_scatter_data(mods_n, prep$S)
+scat_p <- make_scatter_data(mods_p, prep$S_perm)
+scatter_data <- c(scat_n, setNames(scat_p, paste0(names(scat_p), "_p")))
+
+plots_sc <- plot_scatter(scatter_data)
+plots_par <- plot_parameters(prep$param_list)
+
+test_that("plot_scatter returns four recorded plots", {
+  expect_length(plots_sc, 4)
+  expect_true(all(vapply(plots_sc, inherits, logical(1), "recordedplot")))
+})
+
+test_that("plot_parameters returns recorded plots", {
+  expect_true(length(plots_par) >= 0)
+  if (length(plots_par) > 0) {
+    expect_true(all(vapply(plots_par, inherits, logical(1), "recordedplot")))
+  }
+})

--- a/tests/testthat/test_run_pipeline.R
+++ b/tests/testthat/test_run_pipeline.R
@@ -1,0 +1,16 @@
+source("helper_config.R")
+source("../../EDA.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+
+set.seed(6)
+res <- run_pipeline(20, config, c(3,2,1,4))
+
+test_that("run_pipeline returns comprehensive list", {
+  expect_true(all(c("data","models","tables","scatter_data","plots","times","runtime") %in% names(res)))
+  expect_length(res$plots$scatter, 4)
+  expect_true(all(vapply(res$plots$scatter, inherits, logical(1), "recordedplot")))
+  expect_s3_class(res$tables$combined, "knitr_kable")
+})


### PR DESCRIPTION
## Summary
- extrahiere Scatter- und Parameterplots in `plot_scatter` und `plot_parameters`
- rufe neue Plotfunktionen in `create_EDA_report`
- strukturiere `run_pipeline` neu und liefere nun auch erzeugte Plots
- teste Plotfunktionen und erweiterten Pipeline-Output

## Testing
- `lintr::lint_dir()`
- `testthat::test_dir("tests/testthat")`


------
https://chatgpt.com/codex/tasks/task_e_685a7fc1ebc08333a14c4702bf0b45fe