### PR TITLE
Fix Streuplots in main

### DIFF
--- a/main.R
+++ b/main.R
@@ -23,7 +23,13 @@ perm <- c(3, 4, 1, 2)
 #'
 #' @export
 main <- function() {
-  run_pipeline(n, config, perm)
+  res <- run_pipeline(n, config, perm)
+  create_EDA_report(res$data$S$X_tr, config,
+                    scatter_data = res$scatter_data,
+                    table_kbl = res$tables$combined,
+                    param_list = res$data$param_list)
+  print(res$tables$combined)
+  invisible(res)
 }
 
 if (sys.nframe() == 0L) {


### PR DESCRIPTION
## Summary
- print results via `create_EDA_report` so scatter and parameter plots appear
- return pipeline result invisibly and show table in console

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'`
- `Rscript -e 'lintr::lint_dir()'`

------
https://chatgpt.com/codex/tasks/task_e_685a8d67e384833397514d7585dc2fb8