### PR TITLE
Add runtime printout for trtf prediction

### DIFF
--- a/main.R
+++ b/main.R
@@ -33,6 +33,18 @@ main <- function() {
 
   print(tab_normal)
   print(tab_perm)
+
+  hyp_n <- paste(names(mods_norm$models$trtf$best_cfg),
+                 mods_norm$models$trtf$best_cfg,
+                 sep = "=", collapse = ", ")
+  hyp_p <- paste(names(mods_perm$models$trtf$best_cfg),
+                 mods_perm$models$trtf$best_cfg,
+                 sep = "=", collapse = ", ")
+
+  cat(sprintf("TRTF Predict normal: %.2f s [%s]\n",
+              mods_norm$times["trtf"], hyp_n))
+  cat(sprintf("TRTF Predict permutiert: %.2f s [%s]\n",
+              mods_perm$times["trtf"], hyp_p))
   invisible(list(normal = tab_normal, perm = tab_perm))
 }
 


### PR DESCRIPTION
## Summary
- print TRTF prediction runtime and chosen hyperparameters in `main()`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"`
- `R -q -e "lintr::lint_dir('')"`

------
https://chatgpt.com/codex/tasks/task_e_685a971315f4833398d1ae869241f1d2