### PR TITLE
Neues 2x2 Scatterplot-Layout

### DIFF
--- a/main.R
+++ b/main.R
@@ -39,6 +39,36 @@ run_perm <- function(prep, cfg) {
   list(tab = tab, mods = mods)
 }
 
+#' Kombinierte Streuplots anzeigen
+#'
+#' Vier Streudiagramme werden im Layout 2x2 ausgegeben. Die oberen
+#' beiden Plots zeigen die Daten in normaler Reihenfolge, unten folgt
+#' die Permutation. Links steht jeweils der TRTF-Vergleich, rechts der
+#' Vergleich mit KS.
+#'
+#' @param scatter_data Liste mit Einträgen `ld_base`, `ld_trtf`,
+#'   `ld_ks`, `ld_base_p`, `ld_trtf_p`, `ld_ks_p`
+#' @return Ein aufgezeichneter Plot
+plot_scatter_matrix <- function(scatter_data) {
+  op <- par(mfrow = c(2, 2))
+  on.exit(par(op))
+  with(scatter_data, {
+    plot(ld_trtf, ld_base, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+    plot(ld_ks, ld_base, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+    plot(ld_trtf_p, ld_base_p, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+    plot(ld_ks_p, ld_base_p, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+  })
+  recordPlot()
+}
+
 #' Starte die komplette Analyse
 #'
 #' Es werden zwei Log-Likelihood-Tabellen ausgegeben: einmal für die

--- a/tests/testthat/test_plot_scatter_matrix.R
+++ b/tests/testthat/test_plot_scatter_matrix.R
@@ -1,0 +1,21 @@
+source("helper_config.R")
+source("../../04_evaluation.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+sys.source("../../main.R", envir = environment(), chdir = TRUE)
+
+set.seed(7)
+prep <- prepare_data(20, config, c(3,2,1,4))
+mods_n <- fit_models(prep$S, config)
+mods_p <- fit_models(prep$S_perm, config)
+scat_n <- make_scatter_data(mods_n, prep$S)
+scat_p <- make_scatter_data(mods_p, prep$S_perm)
+scatter_data <- c(scat_n, setNames(scat_p, paste0(names(scat_p), "_p")))
+
+plt <- plot_scatter_matrix(scatter_data)
+
+test_that("plot_scatter_matrix returns recorded plot", {
+  expect_s3_class(plt, "recordedplot")
+})


### PR DESCRIPTION
## Summary
- neue Funktion `plot_scatter_matrix` direkt nach `run_perm` eingefügt
- zugehörigen Test `test_plot_scatter_matrix.R` erstellt

## Testing
- `testthat::test_dir('tests/testthat')`
- `lintr::lint_dir()`

------
https://chatgpt.com/codex/tasks/task_e_685a9da5039483338272dc84b49e0a3d