### PR TITLE
Neues Streuplot in main()

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -17,7 +17,7 @@ All densities are evaluated in log-space. Strictly positive parameters are trans
 
 ## 2. Top-Level Pipeline
 The overarching routine `main()` follows the composition
-$$\operatorname{mainPipeline} := f_8 \circ f_7 \circ \cdots \circ f_1,$$
+$$\operatorname{mainPipeline} := f_9 \circ f_8 \circ \cdots \circ f_1,$$
 where
 1. $f_1 = \texttt{gen\_samples}$ – generate $X$ from configuration.
 2. $f_2 = \texttt{train\_test\_split}$ – obtain $(X_{\text{tr}}, X_{\text{te}})$.
@@ -27,6 +27,7 @@ where
 6. $f_6 = \texttt{logL\_\*\_dim}$ – compute dimension-wise log-likelihoods.
 7. $f_7 = \texttt{add\_sum\_row}$ – append totals to tables.
 8. $f_8 = \texttt{combine\_logL\_tables}$ – assemble final evaluation table.
+9. $f_9 = \texttt{plot\_scatter\_matrix}$ – display four log-density scatter plots.
 Optional EDA helper functions are defined in `04_evaluation.R`.
 
 ## 3. Module Specifications

--- a/main.R
+++ b/main.R
@@ -39,6 +39,36 @@ run_perm <- function(prep, cfg) {
   list(tab = tab, mods = mods)
 }
 
+#' Kombinierte Streuplots anzeigen
+#'
+#' Vier Streudiagramme werden im Layout 2x2 ausgegeben. Die oberen
+#' beiden Plots zeigen die Daten in normaler Reihenfolge, unten folgt
+#' die Permutation. Links steht jeweils der TRTF-Vergleich, rechts der
+#' Vergleich mit KS.
+#'
+#' @param scatter_data Liste mit Einträgen `ld_base`, `ld_trtf`,
+#'   `ld_ks`, `ld_base_p`, `ld_trtf_p`, `ld_ks_p`
+#' @return Ein aufgezeichneter Plot
+plot_scatter_matrix <- function(scatter_data) {
+  op <- par(mfrow = c(2, 2))
+  on.exit(par(op))
+  with(scatter_data, {
+    plot(ld_trtf, ld_base, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+    plot(ld_ks, ld_base, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+    plot(ld_trtf_p, ld_base_p, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+    plot(ld_ks_p, ld_base_p, xlab = "predicted log-density",
+         ylab = "true log-density")
+    abline(0, 1)
+  })
+  recordPlot()
+}
+
 #' Starte die komplette Analyse
 #'
 #' Es werden zwei Log-Likelihood-Tabellen ausgegeben: einmal für die
@@ -52,7 +82,14 @@ main <- function() {
   res_norm <- run_normal(prep, config)
   res_perm <- run_perm(prep, config)
 
-  invisible(list(normal = res_norm$tab, perm = res_perm$tab))
+  scat_norm <- make_scatter_data(res_norm$mods, prep$S)
+  scat_perm <- make_scatter_data(res_perm$mods, prep$S_perm)
+  scatter_data <- c(scat_norm,
+                    setNames(scat_perm, paste0(names(scat_perm), "_p")))
+  plt <- plot_scatter_matrix(scatter_data)
+
+  invisible(list(normal = res_norm$tab, perm = res_perm$tab,
+                 scatter_plot = plt))
 }
 
 if (sys.nframe() == 0L) {

--- a/tests/testthat/test_baseline_limit.R
+++ b/tests/testthat/test_baseline_limit.R
@@ -12,3 +12,7 @@ test_that("logL_baseline within +/-10 for N=50", {
   expect_true(all(abs(tab1$logL_baseline[seq_along(config)]) <= 10))
   expect_true(all(abs(tab2$logL_baseline[seq_along(config)]) <= 10))
 })
+
+test_that("main returns recorded scatter plot", {
+  expect_s3_class(res$scatter_plot, "recordedplot")
+})

--- a/tests/testthat/test_plot_scatter_matrix.R
+++ b/tests/testthat/test_plot_scatter_matrix.R
@@ -1,0 +1,21 @@
+source("helper_config.R")
+source("../../04_evaluation.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+sys.source("../../main.R", envir = environment(), chdir = TRUE)
+
+set.seed(7)
+prep <- prepare_data(20, config, c(3,2,1,4))
+mods_n <- fit_models(prep$S, config)
+mods_p <- fit_models(prep$S_perm, config)
+scat_n <- make_scatter_data(mods_n, prep$S)
+scat_p <- make_scatter_data(mods_p, prep$S_perm)
+scatter_data <- c(scat_n, setNames(scat_p, paste0(names(scat_p), "_p")))
+
+plt <- plot_scatter_matrix(scatter_data)
+
+test_that("plot_scatter_matrix returns recorded plot", {
+  expect_s3_class(plt, "recordedplot")
+})


### PR DESCRIPTION
## Summary
- rufe `plot_scatter_matrix()` automatisch in `main()` auf
- erweitere `main()`-Rückgabe um den aufgezeichneten Plot
- passe `ALGORITHM_SPEC.md` entsprechend an
- ergänze Test für den Plot

## Testing
- `testthat::test_dir('tests/testthat')`
- `lintr::lint_dir()`

------
https://chatgpt.com/codex/tasks/task_e_685a9da5039483338272dc84b49e0a3d