### PR TITLE
Tabellen mit Standardabweichung

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -246,6 +246,43 @@ function add_sum_row(tab, label)
     return rbind(tab, sum_row)
 ```
 
+### calc_loglik_tables
+`calc_loglik_tables(models, config) : (list, list) \to data.frame`
+- **Description:** compute mean negative log-likelihoods per dimension for all models.
+- **Pseudocode:**
+```
+function calc_loglik_tables(models, config)
+    tab <- data.frame(dim, distribution,
+                      logL_baseline, logL_trtf, logL_ks)
+    tab <- add_sum_row(tab)
+    return tab
+```
+
+### calc_loglik_sds
+`calc_loglik_sds(models, S, config) : (list, list, list) \to data.frame`
+- **Description:** standard deviations of the negative log-likelihoods across test observations.
+- **Pseudocode:**
+```
+function calc_loglik_sds(models, S, config)
+    sd_true <- sd(-log_density_true(S$X_te)) per dimension
+    sd_trtf <- sd over -predict(TRTF, S$X_te)
+    sd_ks   <- sd over -predict(KS, S$X_te)
+    tab <- data.frame(dim, distribution, sd_true, sd_trtf, sd_ks)
+    add_sum_row(tab)
+```
+
+### format_loglik_table
+`format_loglik_table(tab_mean, tab_sd) : (data.frame, data.frame) \to data.frame`
+- **Description:** combine mean and sd tables to strings of the form `"m ± s"`.
+- **Pseudocode:**
+```
+function format_loglik_table(tab_mean, tab_sd)
+    for each numeric column col
+        tab[col] <- sprintf("%.2f ± %.2f", round(tab_mean[col],2),
+                            round(2 * tab_sd[col],2))
+    return tab
+```
+
 ### combine_logL_tables
 `combine_logL_tables(tab_normal, tab_perm, t_normal, t_perm) : (...) \to kable`
 - **Description:** merge normal/permutation tables and attach runtime information.

--- a/main.R
+++ b/main.R
@@ -17,26 +17,30 @@ perm <- c(3, 4, 1, 2)
 
 run_normal <- function(prep, cfg) {
   mods <- fit_models(prep$S, cfg)
-  tab <- calc_loglik_tables(mods, cfg)
-  print(tab)
+  tab_mean <- calc_loglik_tables(mods, cfg)
+  tab_sd   <- calc_loglik_sds(mods, prep$S, cfg)
+  tab_fmt  <- format_loglik_table(tab_mean, tab_sd)
+  print(tab_fmt)
   hyp <- paste(names(mods$models$trtf$best_cfg),
                mods$models$trtf$best_cfg,
                sep = "=", collapse = ", ")
   cat(sprintf("TRTF Predict normal: %.2f s [%s]\n",
               mods$times["trtf"], hyp))
-  list(tab = tab, mods = mods)
+  list(tab = tab_mean, mods = mods)
 }
 
 run_perm <- function(prep, cfg) {
   mods <- fit_models(prep$S_perm, cfg)
-  tab <- calc_loglik_tables(mods, cfg)
-  print(tab)
+  tab_mean <- calc_loglik_tables(mods, cfg)
+  tab_sd   <- calc_loglik_sds(mods, prep$S_perm, cfg)
+  tab_fmt  <- format_loglik_table(tab_mean, tab_sd)
+  print(tab_fmt)
   hyp <- paste(names(mods$models$trtf$best_cfg),
                mods$models$trtf$best_cfg,
                sep = "=", collapse = ", ")
   cat(sprintf("TRTF Predict permutiert: %.2f s [%s]\n",
               mods$times["trtf"], hyp))
-  list(tab = tab, mods = mods)
+  list(tab = tab_mean, mods = mods)
 }
 
 #' Kombinierte Streuplots anzeigen

--- a/tests/testthat/test_loglik_sd_format.R
+++ b/tests/testthat/test_loglik_sd_format.R
@@ -1,0 +1,25 @@
+source("helper_config.R")
+source("../../04_evaluation.R")
+source("../../models/trtf_model.R")
+source("../../models/ks_model.R")
+source("../../models/true_model.R")
+source("../../02_split.R")
+
+set.seed(7)
+prep <- prepare_data(30, config, c(3,2,1,4))
+mods <- fit_models(prep$S, config)
+
+tab_mean <- calc_loglik_tables(mods, config)
+tab_sd   <- calc_loglik_sds(mods, prep$S, config)
+tab_fmt  <- format_loglik_table(tab_mean, tab_sd)
+
+test_that("calc_loglik_sds works", {
+  expect_true(is.data.frame(tab_sd))
+  expect_equal(nrow(tab_sd), length(config) + 1)
+  expect_true(all(is.finite(tab_sd$logL_trtf)))
+})
+
+test_that("format_loglik_table adds strings", {
+  expect_true(is.character(tab_fmt$logL_baseline))
+  expect_match(tab_fmt$logL_trtf[1], "±")
+})


### PR DESCRIPTION
## Summary
- erweitere Evaluation um `calc_loglik_sds` und `format_loglik_table`
- passe `main.R` an, um formatierte Tabellen mit 2×SD auszugeben
- erweitere Algorithmus-Spezifikation entsprechend

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"`
- `Rscript -e "lintr::lint_dir('.')"` (liefert nur Style-Warnungen)


------
https://chatgpt.com/codex/tasks/task_e_685d9770f1f88333a58b3c922c8a5009