### PR TITLE
Aktualisiere ALGORITHM_SPEC

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -1,19 +1,44 @@
 # Algorithm Specification for Multivariate Density Estimation
 
 ## 1. Notation
-- $K$: dimensionality of the random vector $x=(x_1,\ldots,x_K)^\top$.
+- $d$: dimensionality of the random vector $x=(x_1,\ldots,x_d)^\top$.
 - $N$: number of observations.
 - $\pi(x)$: target density of $x$.
-- $\eta(z)$: density of the $K$-variate standard Gaussian.
-- $S: \mathbb R^K \to \mathbb R^K$: lower triangular transport map, $z = S(x)$.
+- $\eta(z)$: density of the $d$-variate standard Gaussian.
+- $S: \mathbb R^d \to \mathbb R^d$: lower triangular transport map, $z = S(x)$.
 - $S_k$: $k$-th component of $S$ with arguments $x_{1:k}=(x_1,\ldots,x_k)$.
 - $R = S^{-1}$: inverse map, $x = R(z)$.
 - $\nabla S$: Jacobian matrix of $S$.
-- $J(x)=\det(\nabla S(x))$.
-- $X \in \mathbb R^{N\times K}$: matrix of samples where column $j$ corresponds to $x_j$.
-- $\mathcal{N}(0,I_K)$: $K$-variate standard Gaussian distribution.
+- $\ell(x)=\sum_{k=1}^{d} \log\partial_k S_k(x)$.
+- $X \in \mathbb R^{N\times d}$: matrix of samples where column $j$ corresponds to $x_j$.
+- $\mathcal{N}(0,I_d)$: $d$-variate standard Gaussian distribution.
 
 All densities are evaluated in log-space. Strictly positive parameters are transformed via `softplus`.
+```
+########  TTM CORE (shared)  ########
+standardizeData(X)
+sampleReference(N,d)
+shuffleOrdering(d)
+
+struct MapStruct:
+    type ∈ {marginal,separable,cross}
+    coeffA[k], coeffB[k], coeffC[k]
+    basisF[k] : {value, deriv>0}
+    basisG[k], basisH[k]   # basisH_k(t, x_{1:k-1}, θ)
+
+forwardPass(S,x)
+logJacDiag(S,x)
+logDetJacobian(ℓ)=Σℓ
+forwardKLLoss(S,X)
+
+monotoneIntegrator(h,t0,t)=∫exp(min(h(s),100))ds
+rootFind1D(fun,target)    # interval [-10,10]
+inversePass(S,z)
+
+negativeLogLikelihood(S,X)
+natsPerDim(L,N,d)=L/(N·d)
+#####################################
+```
 
 ## 2. Top-Level Pipeline
 The overarching routine `main()` follows the composition
@@ -22,6 +47,9 @@ where
 1. $f_1 = \texttt{gen\_samples}$ – generate $X$ from configuration.
 2. $f_2 = \texttt{train\_test\_split}$ – obtain $(X_{\text{tr}}, X_{\text{te}})$.
 3. $f_3 = \texttt{fit\_TRUE}$ – fit independent parametric marginals.
+   f_3b1 = fit_TTM_marginal
+   f_3b2 = fit_TTM_separable
+   f_3b3 = fit_TTM_cross  # train triangular transport maps via respective trainers
 4. $f_4 = \texttt{fit\_TRTF}$ – fit transformation forests.
 5. $f_5 = \texttt{fit\_KS}$ – fit kernel smoother model.
 6. $f_6 = \texttt{logL\_\*\_dim}$ – compute dimension-wise log-likelihoods.
@@ -52,14 +80,14 @@ function setup_global(cfg)
 `gen_samples(G) : G \to X`
 - **Description:** sequentially draws $N=G.n$ samples from distributions specified in `G.config`.
 - **Pre:** each `config[[k]]$distr` matches an R sampling routine `r<distr>`.
-- **Post:** matrix $X \in \mathbb R^{N\times K}$ with column names $\{X1,\ldots,XK\}$; invalid distribution parameters are clamped to $10^{-3}$.
+- **Post:** matrix $X \in \mathbb R^{N\times d}$ with column names $\{X1,\ldots,Xd\}$; invalid distribution parameters are clamped to $10^{-3}$.
 - **Randomness:** uses `set.seed(G.seed)` and draws via base R generators.
 - **Pseudocode:**
 ```
 function gen_samples(G)
     set seed to G.seed
     for i in 1..G.n
-        for k in 1..K
+        for k in 1..d
             args <- if config[k].parm is null then {} else config[k].parm(previous X_i)
             replace non-finite or <=0 args by 1e-3
             X[i,k] <- r<distr_k>(1, args)
@@ -67,7 +95,7 @@ function gen_samples(G)
 ```
 
 ### train_test_split
-`train_test_split(X, r, seed) : (\mathbb R^{N\times K}, [0,1], \mathbb N) \to (X_{\text{tr}}, X_{\text{te}})`
+`train_test_split(X, r, seed) : (\mathbb R^{N\times d}, [0,1], \mathbb N) \to (X_{\text{tr}}, X_{\text{te}})`
 - **Description:** shuffle rows of $X$ reproducibly and split into training and test matrices.
 - **Pre:** $0<r<1$.
 - **Post:** $X_{\text{tr}}$ has $\lfloor rN\rfloor$ rows; $X_{\text{te}}$ contains the remainder.
@@ -82,7 +110,7 @@ function train_test_split(X, r, seed)
 ```
 
 ### fit_TRUE
-`fit_TRUE(X_tr, X_te, config) : (\mathbb R^{n_{tr}\times K}, \mathbb R^{n_{te}\times K}, config) \to M_{TRUE}`
+`fit_TRUE(X_tr, X_te, config) : (\mathbb R^{n_{tr}\times d}, \mathbb R^{n_{te}\times d}, config) \to M_{TRUE}`
 - **Description:** independent maximum-likelihood estimation per dimension.
 - **Pre:** distributions in `config` supported by `neg_loglik_uni`.
 - **Post:** list with parameter estimates `theta` and test log-likelihood `logL_te`.
@@ -90,7 +118,7 @@ function train_test_split(X, r, seed)
 - **Pseudocode:**
 ```
 function fit_TRUE(X_tr, X_te, config)
-    for k in 1..K
+    for k in 1..d
         init <- moment_based_start(X_tr[,k], config[k].distr)
         theta_k <- optimize neg_loglik_uni w.r.t. init
     logL_te <- logL_TRUE((theta), X_te)
@@ -98,17 +126,17 @@ function fit_TRUE(X_tr, X_te, config)
 ```
 
 ### logL_TRUE
-`logL_TRUE(M_TRUE, X) : (M_{TRUE}, \mathbb R^{n\times K}) \to \mathbb R`
-- **Description:** evaluate mean negative log-likelihood of `X` under the independent model.
+`logL_TRUE(M_TRUE, X) : (M_{TRUE}, \mathbb R^{n\times d}) \to \mathbb R`
+- **Description:** evaluate Gesamt-NLL of `X` under the independent model.
 - **Pre:** fitted parameters in `M_TRUE` are valid.
 - **Post:** scalar value finite.
 - **Randomness:** none.
 - **Pseudocode:**
 ```
 function logL_TRUE(M, X)
-    for k in 1..K
+    for k in 1..d
         ll_k <- log_density_vec(X[,k], distr_k, M.theta[[k]])
-    return -mean(rowSums(ll_k))
+    return -sum(rowSums(ll_k))
 ```
 
 ### fit_KS
@@ -128,15 +156,15 @@ function fit_KS(X_tr, X_te, config, seed)
 ```
 
 ### logL_KS
-`logL_KS(model, X) : (M_{KS}, \mathbb R^{n\times K}) \to \mathbb R`
-- **Description:** mean negative log-likelihood via sequential KDE evaluation.
+`logL_KS(model, X) : (M_{KS}, \mathbb R^{n\times d}) \to \mathbb R`
+- **Description:** Gesamt-NLL via sequential KDE evaluation.
 - **Pre:** bandwidths $h>0$.
 - **Post:** finite scalar.
 - **Pseudocode:**
 ```
 function logL_KS(model, X)
     ll <- predict.ks_model(model, X, 'logdensity')
-    return -mean(ll)
+    return -sum(ll)
 ```
 
 ### fit_TRTF
@@ -163,19 +191,19 @@ function fit_TRTF(X_tr, X_te, config, grid, folds, seed)
 ```
 
 ### logL_TRTF
-`logL_TRTF(model, X) : (M_{TRTF}, \mathbb R^{n\times K}) \to \mathbb R`
-- **Description:** mean negative log-likelihood for the TRTF model.
+`logL_TRTF(model, X) : (M_{TRTF}, \mathbb R^{n\times d}) \to \mathbb R`
+- **Description:** Gesamt-NLL for the TRTF model.
 - **Pre:** forest predictions finite.
 - **Post:** scalar value.
 - **Pseudocode:**
 ```
 function logL_TRTF(model, X)
     ll <- predict.mytrtf(model, X, 'logdensity')
-    return -mean(ll)
+    return -sum(ll)
 ```
 
 ### standardize_data
-`standardize_data(X) : \mathbb R^{N\times K} \to (\tilde X, \mu, \sigma)`
+`standardize_data(X) : \mathbb R^{N\times d} \to (\tilde X, \mu, \sigma)`
 - **Description:** zentriert und skaliert jede Spalte von `X`.
 - **Pseudocode:**
 ```
@@ -186,29 +214,30 @@ function standardize_data(X)
 ```
 
 ### sample_reference
-`sample_reference(N, K, seed) : (\mathbb N, \mathbb N, \mathbb N) \to Z`
-- **Description:** erzeugt `N` Standardnormal-Samples der Dimension `K`.
+`sample_reference(N, d, seed) : (\mathbb N, \mathbb N, \mathbb N) \to Z`
+- **Description:** erzeugt `N` Standardnormal-Samples der Dimension `d`.
 - **Pseudocode:**
 ```
-function sample_reference(N, K, seed)
+function sample_reference(N, d, seed)
     set seed to seed
-    return matrix of rnorm(N*K) reshaped (N,K)
+    return matrix of rnorm(N*d) reshaped (N,d)
 ```
 
 ### shuffle_ordering
-`shuffle_ordering(K, seed) : (\mathbb N, \mathbb N) \to \pi`
+`shuffle_ordering(d, seed) : (\mathbb N, \mathbb N) \to \pi`
 - **Description:** optionale Permutation der Spaltenindizes.
 - **Pseudocode:**
 ```
-function shuffle_ordering(K, seed)
+function shuffle_ordering(d, seed)
     set seed to seed
-    return random permutation of 1..K
+    return random permutation of 1..d
 ```
 
 
 ### MapStruct
 `MapStruct(type, coeffA, coeffB, coeffC, basisF, basisG, basisH)`
 - **BasisF API:** Each `basisF_k` must implement two callables: `value(x,\theta)` and `deriv(x,\theta) > 0`.
+- *basisH_k muss die Signatur **h_k(t , x_{1:k-1},\,\theta)** besitzen.*
 - **Description:** Container-Objekt für Koeffizienten und Basisfunktionen einer triangularen Map.
 - **Pseudocode:**
 ```
@@ -220,15 +249,15 @@ struct MapStruct:
     basisF[k], basisG[k], basisH[k]   # callable handles
 ```
 ### evaluate_all
-`evaluate_all(X_te, model_list) : (\mathbb R^{n_{te}\times K}, list) \to \text{data.frame}`
+`evaluate_all(X_te, model_list) : (\mathbb R^{n_{te}\times d}, list) \to \text{data.frame}`
 - **Description:** compute negative log-likelihoods for named models via dynamic dispatch.
 - **Pseudocode:**
 ```
 function evaluate_all(X_te, model_list)
     for each model with name id
         loss <- logL_<id>(model, X_te)
-        store (id, loss)
-    sort by loss
+        store (id, loss)  # column totalNLL
+    sort by totalNLL
     return table
 ```
 
@@ -244,7 +273,7 @@ function add_sum_row(tab, label)
 
 ### calc_loglik_tables
 `calc_loglik_tables(models, config) : (list, list) \to data.frame`
-- **Description:** compute mean negative log-likelihoods per dimension for all models.
+- **Description:** compute Gesamt-NLLs per dimension for all models.
 - **Pseudocode:**
 ```
 function calc_loglik_tables(models, config)
@@ -291,17 +320,20 @@ function format_loglik_table(tab_mean, tab_sd)
 Each module drawing random numbers sets the RNG via `set.seed` with an integer seed. Seeds are derived from the global seed (`G.seed`) with deterministic offsets. Random variables are sampled from base R distributions (`rnorm`, `rexp`, `rbeta`, `rgamma`) or via transformation forests and kernel smoothing. All optimization routines are deterministic given these seeds. To reproduce results, record `G.seed` and any hyperparameter grid.
 
 ## 5. Complexity Notes
-- `gen_samples`: $\Theta(NK)$.
-- `train_test_split`: $\Theta(N)$ for shuffling.
-- `fit_TRUE`: dominated by optimization per dimension; roughly $\Theta(K n_{tr} I)$ with iteration count $I$.
-- `fit_KS`: kernel evaluations yield $\Theta(n_{te} n_{tr} K)$ during prediction.
+- `gen_samples`: $\\Theta(Nd)$.
+- `train_test_split`: $\\Theta(N)$ for shuffling.
+- `fit_TRUE`: dominated by optimization per dimension; roughly $\\Theta(d n_{tr} I)$ with iteration count $I$.
+- `fit_KS`: kernel evaluations yield $\\Theta(n_{te} n_{tr} d)$ during prediction.
 - `fit_TRTF` complexity hängt von der Tiefe der Bäume ab und ist datengesteuert.
 
+- Marginal-TTM:  \\Theta(N d)
+- Separable-TTM: \\Theta(N d) + LS-Solves
+- Cross-term-TTM: \\Theta(N d B) pro SGD-Batch
 ## 6. Appendix A – Data Schemas
 - **Configuration Entry**: list with fields
   - `distr`: string naming the distribution family.
   - `parm`: optional function returning a list of parameters given previous columns.
-- **Sample Matrix** `X`: numeric matrix with columns `X1` … `XK`.
+- **Sample Matrix** `X`: numeric matrix with columns `X1` … `Xd`.
 - **Model Objects**:
   - `M_TRUE`: list `theta` (per-dimension parameter vectors), `config`, `logL_te`.
   - `ks_model`: list `X_tr`, `h`, `config`, `logL_te`.
@@ -311,6 +343,6 @@ Each module drawing random numbers sets the RNG via `set.seed` with an integer s
   - `logDetJacobian(logDiag)` → sum of log-diagonal entries.
   - `forwardKLLoss(S,X)` → mean forward-KL objective.
   - `negativeLogLikelihood(S,X)` → total NLL of dataset.
-  - `natsPerDim(NLL,N,d)` → normalized NLL per dimension.
+  - `natsPerDim(L,N,d)=L/(N·d)` → normalized NLL per dimension.
 
 


### PR DESCRIPTION
## Zusammenfassung
- globale Notation auf `d` geändert und log-Jacobian neu definiert
- gemeinsamen TTM-Core-Pseudocode eingefügt
- Hinweis zur Signatur von `basisH_k` ergänzt
- Trainingsschritte für TTM-Varianten ergänzt
- Loglikelihood-Routinen und `evaluate_all` angepasst
- Komplexitätshinweise und `natsPerDim` aktualisiert

## Testing
- Keine Tests erforderlich (nur Dokumentationsänderungen)

------
https://chatgpt.com/codex/tasks/task_e_6864d851a0a48333974bdb0bfaedfe6a