### PR TITLE
Fix BoxCox dependencies and SUM row

### DIFF
--- a/00_globals.R
+++ b/00_globals.R
@@ -1,5 +1,7 @@
 library(dplyr)
 library(parallel)
+library(tram)
+library(trtf)
 if (!exists("NC")) NC <- detectCores()
 options(mc.cores = NC)
 

--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -120,13 +120,14 @@ calc_loglik_tables <- function(models, config, X_te) {
     stringsAsFactors = FALSE
   )
 
+  se_sum_ttm <- if (is.null(models$ttm)) NA_real_ else models$ttm$stderr_test
   sum_row <- data.frame(
     dim = "k",
     distribution = "SUM",
     true = fmt(sum(mean_true), se_sum_true),
     trtf = fmt(sum(mean_trtf), se_sum_trtf),
     ks   = fmt(sum(mean_ks),   se_sum_ks),
-    ttm  = fmt(sum(mean_ttm),  models$ttm$stderr_test),
+    ttm  = fmt(sum(mean_ttm),  se_sum_ttm),
     stringsAsFactors = FALSE
   )
   rbind(tab, sum_row)


### PR DESCRIPTION
## Summary
- lade `tram` und `trtf` in den globalen Einstellungen
- korrigiere die Berechnung der Summenzeile in `calc_loglik_tables`

## Testing
- `Rscript -e 'lintr::lint_dir(".")' | head`
- `Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_686eb1f6c10c8333ac99968dbbf312da