### PR TITLE
Add seed handling to TRTF and clamp marginal ranks

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -133,18 +133,19 @@ function logL_KS(model, X)
 ```
 
 ### fit_TRTF
-`fit_TRTF(S, config, ntree, mtry, minsplit, minbucket, maxdepth, seed, cores) : S \to M_{TRTF}`
+`fit_TRTF(S, config, seed, cores) : S \to M_{TRTF}`
 - **Description:** one-shot fit of conditional transformation forest on train data, evaluation on test.
 - **Pre:** training and test matrices present in `S`.
 - **Post:** fitted forest with test log-likelihood.
-- **Randomness:** `set.seed(seed)` affects forest construction.
+- **Randomness:** optional `set.seed(seed)` affects forest construction.
 - **Pseudocode:**
 ```
-function fit_TRTF(S, config, ntree, mtry, minsplit, minbucket, maxdepth, seed, cores)
-    set seed to seed
+function fit_TRTF(S, config, seed, cores)
+    if seed is not NULL:
+        set seed to seed
     X_tr <- S.X_tr
     X_te <- S.X_te
-    mod <- mytrtf(X_tr, ntree, mtry, minsplit, minbucket, maxdepth, seed, cores)
+    mod <- mytrtf(X_tr, ntree = nrow(X_tr), minsplit, minbucket, maxdepth, seed, cores)
     mod.logL_te <- logL_TRTF(mod, X_te, cores)
     return mod
 ```

--- a/main.R
+++ b/main.R
@@ -31,7 +31,7 @@ main <- function() {
   prep <- prepare_data(n, config, seed = 42)
   mods <- list(
     true = fit_TRUE(prep$S, config),
-    trtf = fit_TRTF(prep$S, config),
+    trtf = fit_TRTF(prep$S, config, seed = 42),
     ks   = fit_KS(prep$S, config),
     ttm  = trainMarginalMap(prep$S)
   )

--- a/models/trtf_model.R
+++ b/models/trtf_model.R
@@ -82,20 +82,20 @@ logL_TRTF_dim <- function(model, X, cores = NC) {
   res
 }
 
-fit_TRTF <- function(S, config, cores = NC) {
+fit_TRTF <- function(S, config, seed = NULL, cores = NC) {
   stopifnot(is.list(S))
   X_tr <- S$X_tr
   X_te <- S$X_te
   stopifnot(is.matrix(X_tr), is.matrix(X_te))
-  
-  set.seed(p$seed)
-  
+
+  if (!is.null(seed)) set.seed(seed)
+
   mod <- mytrtf(data = X_tr,
                 ntree = nrow(X_tr),
                 minsplit = p$minsplit,
                 minbucket = p$minbucket,
                 maxdepth = p$maxdepth,
-                seed = p$seed,
+                seed = seed,
                 cores = cores)
   
   mod$config  <- config

--- a/models/ttm_marginal.R
+++ b/models/ttm_marginal.R
@@ -48,9 +48,10 @@ trainMarginalMap <- function(X_or_path) {
     coeffB <- numeric(K)
     for (k in seq_len(K)) {
       xk <- X_tr_std[, k]
-      u <- rank(xk, ties.method = "average") / (length(xk) + 1)
-      lower <- 1 / (length(xk) + 1)
-      upper <- length(xk) / (length(xk) + 1)
+      N <- length(xk)
+      u <- rank(xk, ties.method = "average") / (N + 1)
+      lower <- 1 / (N + 1)
+      upper <- N / (N + 1)
       u <- pmin(pmax(u, lower), upper)
       z_star <- qnorm(u)
       covxz <- mean((xk - mean(xk)) * (z_star - mean(z_star)))


### PR DESCRIPTION
## Summary
- allow `fit_TRTF` to accept an optional seed and forward it to the trainer
- call `fit_TRTF` with a fixed seed from `main.R`
- bound marginal rank transformation with averaged ties

## Testing
- `R -q -e "lintr::lint('models/trtf_model.R'); lintr::lint('models/ttm_marginal.R'); lintr::lint('main.R')"`
- `R -q -e "testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_689b76420058833391c0018ca6329ca5