### PR TITLE
Clarify NLL units in evaluation output

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -138,6 +138,7 @@ calc_loglik_tables <- function(models, config, X_te) {
   nm[nm == "trtf"] <- "Random Forest"
   nm[nm == "ttm"]  <- "Marginal Map"
   names(tab) <- nm
+  message("Ergebnis (NLL in nats; lower is better)")
   tab
 }
 


### PR DESCRIPTION
## Summary
- Print explicit unit note before main evaluation table.

## Testing
- `Rscript -e "lintr::lint('04_evaluation.R')"`
- `Rscript main.R`
- `Rscript -e "testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_689b7654dff08333879c6829c35fafa4