### PR TITLE
Seed-Handling in fit_TRTF für deterministische Abläufe

### DIFF
--- a/main.R
+++ b/main.R
@@ -28,6 +28,13 @@ config <- list(
 #' 
 #' @export
 main <- function() {
+  old_mc <- getOption("mc.cores")
+  on.exit({ options(mc.cores = old_mc) }, add = TRUE)
+  options(mc.cores = 1)
+  old_NC <- NC
+  on.exit({ NC <<- old_NC }, add = TRUE)
+  NC <<- 1
+
   prep <- prepare_data(n, config, seed = 42)
   mods <- list(
     true = fit_TRUE(prep$S, config),


### PR DESCRIPTION
## Summary
- Isoliere RNG-Zustand in `fit_TRTF` mit lokalem `seed` und setze `mc.cores` temporär auf 1
- Erzwinge sequentielle Ausführung in `main()` durch Anpassung von `mc.cores` und `NC`

## Testing
- `Rscript -e "lintr::lint('models/trtf_model.R')"`
- `Rscript -e "lintr::lint('main.R')"`
- `Rscript -e "testthat::test_dir('tests/testthat')"`
- `Rscript -e "source('main.R'); tab1 <- main(); tab2 <- main(); print(identical(tab1[['Random Forest']], tab2[['Random Forest']]))"` *(fails: FALSE)*

------
https://chatgpt.com/codex/tasks/task_e_689c33e4f868833386430a930cbf739e