### PR TITLE
Integrate separable transport map into main pipeline

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -4,6 +4,7 @@ if (basename(root_path) == "testthat") {
   root_path <- dirname(dirname(root_path))
 }
 source(file.path(root_path, "models/ttm_marginal.R"))
+source(file.path(root_path, "models/ttm_separable.R"))
 source(file.path(root_path, "models/ks_model.R"))
 
 #' Summen-Zeile an Tabelle anh\u00e4ngen

--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -28,6 +28,13 @@ stderr(v)
 ######################################
 ```
 
+```
+########  TTM CORE (separable) ########
+trainSeparableMap(X_or_path)
+predict.ttm_separable(S, X, type)
+######################################
+```
+
 ## 2. Top-Level Pipeline
 The overarching routine `main()` follows the composition
 $$\operatorname{mainPipeline} := f_9 \circ f_8 \circ \cdots \circ f_1,$$

--- a/main.R
+++ b/main.R
@@ -5,6 +5,7 @@ source("models/true_model.R")
 source("models/trtf_model.R")
 source("models/ks_model.R")
 source("models/ttm_marginal.R")
+source("models/ttm_separable.R")
 source("04_evaluation.R")
 source("replicate_code.R")
 
@@ -28,12 +29,14 @@ config <- list(
 #' 
 #' @export
 main <- function() {
+  set.seed(42)
   prep <- prepare_data(n, config, seed = 42)
   mods <- list(
     true = fit_TRUE(prep$S, config),
     trtf = fit_TRTF(prep$S, config, seed = 42),
     ks   = fit_KS(prep$S, config),
-    ttm  = trainMarginalMap(prep$S)
+    ttm  = trainMarginalMap(prep$S),
+    ttm_sep = trainSeparableMap(prep$S)
   )
   tab <- calc_loglik_tables(mods, config, prep$S$X_te)
   print(tab)

--- a/models/ttm_separable.R
+++ b/models/ttm_separable.R
@@ -1,0 +1,164 @@
+# Triangular Transport Map - Separable Modul
+# Basis-R Implementierung nach Appendix A
+
+# Hilfsfunktionen ------------------------------------------------------------
+
+if (!exists(".standardizeData")) {
+  .standardizeData <- function(X) {
+    mu <- colMeans(X)
+    sigma <- apply(X, 2, sd) + .Machine$double.eps
+    X_tilde <- sweep(X, 2, mu, "-")
+    X_tilde <- sweep(X_tilde, 2, sigma, "/")
+    list(X = X_tilde, mu = mu, sigma = sigma)
+  }
+}
+
+if (!exists(".standardize")) {
+  .standardize <- function(S, X) {
+    X <- sweep(X, 2, S$mu, "-")
+    sweep(X, 2, S$sigma, "/")
+  }
+}
+
+erf <- function(x) 2 * pnorm(x * sqrt(2)) - 1
+
+basis_f <- function(x) cbind(x, erf(x))
+
+dbasis_f <- function(x) {
+  cbind(rep(1, length(x)), 2 / sqrt(pi) * exp(-x^2))
+}
+
+basis_g <- function(X, deg) {
+  if (ncol(X) == 0L) {
+    return(matrix(0, nrow = nrow(X), ncol = 0))
+  }
+  N <- nrow(X)
+  out <- matrix(1, N, 1)
+  for (j in seq_len(ncol(X))) {
+    xj <- X[, j]
+    for (d in seq_len(deg)) {
+      out <- cbind(out, xj^d)
+    }
+  }
+  out
+}
+
+# Exportierte Funktionen -----------------------------------------------------
+
+trainSeparableMap <- function(X_or_path, degree_g = 2, lambda = 1e-3, eps = 1e-6) {
+  set.seed(42)
+  S_in <- if (is.character(X_or_path)) readRDS(X_or_path) else X_or_path
+  stopifnot(is.list(S_in))
+  X_tr <- S_in$X_tr
+  X_val <- S_in$X_val
+  X_te  <- S_in$X_te
+
+  time_train <- system.time({
+    std <- .standardizeData(X_tr)
+    X_tr_std <- std$X
+    mu <- std$mu
+    sigma <- std$sigma
+    K <- ncol(X_tr_std)
+    coeffs <- vector("list", K)
+    N <- nrow(X_tr_std)
+    for (k in seq_len(K)) {
+      x_prev <- if (k > 1) X_tr_std[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
+      xk <- X_tr_std[, k]
+      P_non <- if (k > 1) basis_g(x_prev, degree_g) else matrix(0, N, 0)
+      P_mon <- basis_f(xk)
+      B <- dbasis_f(xk)
+      stopifnot(nrow(P_mon) == N, nrow(P_non) == N, nrow(B) == N)
+      m_non <- ncol(P_non)
+      m_mon <- ncol(P_mon)
+      if (m_non > 0) {
+        M <- solve(crossprod(P_non) + lambda * diag(m_non), t(P_non))
+        A <- (diag(N) - P_non %*% M) %*% P_mon
+        D <- M %*% P_mon
+      } else {
+        M <- matrix(0, 0, N)
+        A <- P_mon
+        D <- matrix(0, 0, m_mon)
+      }
+      fn <- function(c) {
+        r <- A %*% c
+        Bc <- B %*% c
+        if (any(Bc <= 0)) return(Inf)
+        q <- D %*% c
+        0.5 * sum(r^2) - sum(log(Bc)) + (lambda / 2) * (sum(q^2) + sum(c^2))
+      }
+      gr <- function(c) {
+        r <- A %*% c
+        Bc <- B %*% c
+        q <- D %*% c
+        as.numeric(t(A) %*% r - t(B) %*% (1 / Bc) + lambda * (t(D) %*% q + c))
+      }
+      c0 <- rep(1, m_mon)
+      opt <- optim(c0, fn, gr, method = "L-BFGS-B", lower = rep(eps, m_mon))
+      c_mon <- opt$par
+      c_non <- if (m_non > 0) -M %*% (P_mon %*% c_mon) else numeric(0)
+      coeffs[[k]] <- list(c_non = c_non, c_mon = c_mon)
+    }
+    S_map <- list(
+      mu = mu,
+      sigma = sigma,
+      coeffs = coeffs,
+      degree_g = degree_g,
+      order = seq_len(K)
+    )
+    class(S_map) <- "ttm_separable"
+  })[["elapsed"]]
+  time_pred <- system.time({
+    predict(S_map, X_te, "logdensity_by_dim")
+  })[["elapsed"]]
+
+  list(
+    S = S_map,
+    NLL_train = NLL_set(S_map, X_tr),
+    NLL_val = NLL_set(S_map, X_val),
+    NLL_test = NLL_set(S_map, X_te),
+    stderr_test = SE_set(S_map, X_te),
+    time_train = time_train,
+    time_pred = time_pred
+  )
+}
+
+predict.ttm_separable <- function(object, newdata,
+                                  type = c("logdensity_by_dim", "logdensity")) {
+  type <- tryCatch(match.arg(type), error = function(e) stop("unknown type"))
+  Xs <- .standardize(object, newdata)
+  N <- nrow(Xs)
+  K <- ncol(Xs)
+  Z <- matrix(0, N, K)
+  LJ <- matrix(0, N, K)
+  for (k in seq_len(K)) {
+    x_prev <- if (k > 1) Xs[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
+    xk <- Xs[, k]
+    P_non <- if (k > 1) basis_g(x_prev, object$degree_g) else matrix(0, N, 0)
+    P_mon <- basis_f(xk)
+    B <- dbasis_f(xk)
+    c_non <- object$coeffs[[k]]$c_non
+    c_mon <- object$coeffs[[k]]$c_mon
+    gk <- if (ncol(P_non) > 0) as.numeric(P_non %*% c_non) else rep(0, N)
+    fk <- as.numeric(P_mon %*% c_mon)
+    Z[, k] <- gk + fk
+    deriv <- (B %*% c_mon) / object$sigma[k]
+    LJ[, k] <- log(as.numeric(deriv))
+  }
+  C <- -0.5 * log(2 * pi)
+  LD <- (-0.5) * (Z^2) + C + LJ
+  if (type == "logdensity_by_dim") {
+    LD
+  } else {
+    rowSums(LD)
+  }
+}
+
+NLL_set <- function(S, X) {
+  mean(-rowSums(predict(S, X, "logdensity_by_dim")))
+}
+
+SE_set <- function(S, X) {
+  v <- rowSums(-predict(S, X, "logdensity_by_dim"))
+  stats::sd(v) / sqrt(length(v))
+}
+

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -484,12 +484,161 @@ stats::sd(v) / sqrt(length(v))
 }
 ### End models/ttm_marginal.R ###
 
+### Begin models/ttm_separable.R ###
+if (!exists(".standardizeData")) {
+.standardizeData <- function(X) {
+mu <- colMeans(X)
+sigma <- apply(X, 2, sd) + .Machine$double.eps
+X_tilde <- sweep(X, 2, mu, "-")
+X_tilde <- sweep(X_tilde, 2, sigma, "/")
+list(X = X_tilde, mu = mu, sigma = sigma)
+}
+}
+if (!exists(".standardize")) {
+.standardize <- function(S, X) {
+X <- sweep(X, 2, S$mu, "-")
+sweep(X, 2, S$sigma, "/")
+}
+}
+erf <- function(x) 2 * pnorm(x * sqrt(2)) - 1
+basis_f <- function(x) cbind(x, erf(x))
+dbasis_f <- function(x) {
+cbind(rep(1, length(x)), 2 / sqrt(pi) * exp(-x^2))
+}
+basis_g <- function(X, deg) {
+if (ncol(X) == 0L) {
+return(matrix(0, nrow = nrow(X), ncol = 0))
+}
+N <- nrow(X)
+out <- matrix(1, N, 1)
+for (j in seq_len(ncol(X))) {
+xj <- X[, j]
+for (d in seq_len(deg)) {
+out <- cbind(out, xj^d)
+}
+}
+out
+}
+trainSeparableMap <- function(X_or_path, degree_g = 2, lambda = 1e-3, eps = 1e-6) {
+set.seed(42)
+S_in <- if (is.character(X_or_path)) readRDS(X_or_path) else X_or_path
+stopifnot(is.list(S_in))
+X_tr <- S_in$X_tr
+X_val <- S_in$X_val
+X_te  <- S_in$X_te
+time_train <- system.time({
+std <- .standardizeData(X_tr)
+X_tr_std <- std$X
+mu <- std$mu
+sigma <- std$sigma
+K <- ncol(X_tr_std)
+coeffs <- vector("list", K)
+N <- nrow(X_tr_std)
+for (k in seq_len(K)) {
+x_prev <- if (k > 1) X_tr_std[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
+xk <- X_tr_std[, k]
+P_non <- if (k > 1) basis_g(x_prev, degree_g) else matrix(0, N, 0)
+P_mon <- basis_f(xk)
+B <- dbasis_f(xk)
+stopifnot(nrow(P_mon) == N, nrow(P_non) == N, nrow(B) == N)
+m_non <- ncol(P_non)
+m_mon <- ncol(P_mon)
+if (m_non > 0) {
+M <- solve(crossprod(P_non) + lambda * diag(m_non), t(P_non))
+A <- (diag(N) - P_non %*% M) %*% P_mon
+D <- M %*% P_mon
+} else {
+M <- matrix(0, 0, N)
+A <- P_mon
+D <- matrix(0, 0, m_mon)
+}
+fn <- function(c) {
+r <- A %*% c
+Bc <- B %*% c
+if (any(Bc <= 0)) return(Inf)
+q <- D %*% c
+0.5 * sum(r^2) - sum(log(Bc)) + (lambda / 2) * (sum(q^2) + sum(c^2))
+}
+gr <- function(c) {
+r <- A %*% c
+Bc <- B %*% c
+q <- D %*% c
+as.numeric(t(A) %*% r - t(B) %*% (1 / Bc) + lambda * (t(D) %*% q + c))
+}
+c0 <- rep(1, m_mon)
+opt <- optim(c0, fn, gr, method = "L-BFGS-B", lower = rep(eps, m_mon))
+c_mon <- opt$par
+c_non <- if (m_non > 0) -M %*% (P_mon %*% c_mon) else numeric(0)
+coeffs[[k]] <- list(c_non = c_non, c_mon = c_mon)
+}
+S_map <- list(
+mu = mu,
+sigma = sigma,
+coeffs = coeffs,
+degree_g = degree_g,
+order = seq_len(K)
+)
+class(S_map) <- "ttm_separable"
+})[["elapsed"]]
+time_pred <- system.time({
+predict(S_map, X_te, "logdensity_by_dim")
+})[["elapsed"]]
+list(
+S = S_map,
+NLL_train = NLL_set(S_map, X_tr),
+NLL_val = NLL_set(S_map, X_val),
+NLL_test = NLL_set(S_map, X_te),
+stderr_test = SE_set(S_map, X_te),
+time_train = time_train,
+time_pred = time_pred
+)
+}
+predict.ttm_separable <- function(object, newdata,
+type = c("logdensity_by_dim", "logdensity")) {
+type <- tryCatch(match.arg(type), error = function(e) stop("unknown type"))
+Xs <- .standardize(object, newdata)
+N <- nrow(Xs)
+K <- ncol(Xs)
+Z <- matrix(0, N, K)
+LJ <- matrix(0, N, K)
+for (k in seq_len(K)) {
+x_prev <- if (k > 1) Xs[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
+xk <- Xs[, k]
+P_non <- if (k > 1) basis_g(x_prev, object$degree_g) else matrix(0, N, 0)
+P_mon <- basis_f(xk)
+B <- dbasis_f(xk)
+c_non <- object$coeffs[[k]]$c_non
+c_mon <- object$coeffs[[k]]$c_mon
+gk <- if (ncol(P_non) > 0) as.numeric(P_non %*% c_non) else rep(0, N)
+fk <- as.numeric(P_mon %*% c_mon)
+Z[, k] <- gk + fk
+deriv <- (B %*% c_mon) / object$sigma[k]
+LJ[, k] <- log(as.numeric(deriv))
+}
+C <- -0.5 * log(2 * pi)
+LD <- (-0.5) * (Z^2) + C + LJ
+if (type == "logdensity_by_dim") {
+LD
+} else {
+rowSums(LD)
+}
+}
+NLL_set <- function(S, X) {
+mean(-rowSums(predict(S, X, "logdensity_by_dim")))
+}
+SE_set <- function(S, X) {
+v <- rowSums(-predict(S, X, "logdensity_by_dim"))
+stats::sd(v) / sqrt(length(v))
+}
+### End models/ttm_separable.R ###
+
 ### Begin 04_evaluation.R ###
 root_path <- getwd()
 if (basename(root_path) == "testthat") {
 root_path <- dirname(dirname(root_path))
 }
 source(file.path(root_path, "models/ttm_marginal.R"))
+source(file.path(root_path, "models/ttm_separable.R"))
 source(file.path(root_path, "models/ks_model.R"))
 add_sum_row <- function(tab, label = "k") {
 stopifnot(is.data.frame(tab))
@@ -649,6 +798,7 @@ source("models/true_model.R")
 source("models/trtf_model.R")
 source("models/ks_model.R")
 source("models/ttm_marginal.R")
+source("models/ttm_separable.R")
 source("04_evaluation.R")
 source("replicate_code.R")
 n <- 50
@@ -663,12 +813,14 @@ parm = function(d) list(shape = softplus(d$X3),
 scale = softplus(d$X2)))
 )
 main <- function() {
+set.seed(42)
 prep <- prepare_data(n, config, seed = 42)
 mods <- list(
 true = fit_TRUE(prep$S, config),
 trtf = fit_TRTF(prep$S, config, seed = 42),
 ks   = fit_KS(prep$S, config),
-ttm  = trainMarginalMap(prep$S)
+ttm  = trainMarginalMap(prep$S),
+ttm_sep = trainSeparableMap(prep$S)
 )
 tab <- calc_loglik_tables(mods, config, prep$S$X_te)
 print(tab)
@@ -682,10 +834,10 @@ replicate_code_scripts("main.R", "replicated_code.txt", env = globalenv())
 ### End main.R ###
 
 ### Final results table ###
-  dim distribution         true Random Forest           ks Marginal Map
-1   1         norm  1.14 ± 0.15   1.15 ± 0.25  1.16 ± 0.22  1.22 ± 0.12
-2   2          exp  1.61 ± 0.63   1.75 ± 0.79  1.51 ± 0.35  2.36 ± 0.06
-3   3         beta -0.14 ± 0.60  -0.26 ± 0.48 -0.39 ± 0.85 -0.05 ± 0.10
-4   4        gamma  1.65 ± 0.83   1.66 ± 0.83  1.47 ± 0.73  2.57 ± 0.04
-5   k          SUM  4.26 ± 1.19   4.31 ± 1.59  3.75 ± 1.65  6.10 ± 0.21
+  dim distribution         true Random Forest            ks Marginal Map
+1   1         norm  1.55 ± 0.47   1.62 ± 0.42   1.60 ± 0.46  1.57 ± 0.38
+2   2          exp  1.65 ± 0.63   2.73 ± 1.00   2.06 ± 0.62  3.30 ± 0.01
+3   3         beta -0.75 ± 1.23  -0.12 ± 0.52  -0.15 ± 0.70  0.41 ± 0.22
+4   4        gamma  2.93 ± 1.97   2.72 ± 1.98 10.90 ± 11.98  3.32 ± 1.45
+5   k          SUM  5.38 ± 2.03   6.95 ± 3.02 14.40 ± 12.48  8.59 ± 1.77
 

--- a/tests/testthat/test_ttm_separable_predictor.R
+++ b/tests/testthat/test_ttm_separable_predictor.R
@@ -1,0 +1,26 @@
+source("helper_config.R")
+source("../../04_evaluation.R")
+
+set.seed(13)
+prep <- prepare_data(30, config)
+fit <- trainSeparableMap(prep$S)
+
+X_te <- prep$S$X_te
+ld_by_dim <- predict(fit$S, X_te, "logdensity_by_dim")
+ld_total <- predict(fit$S, X_te, "logdensity")
+
+N <- nrow(X_te)
+K <- ncol(X_te)
+
+test_that("logdensity_by_dim liefert korrekte Form", {
+  expect_equal(dim(ld_by_dim), c(N, K))
+})
+
+test_that("Keine NA oder Inf in den Logdichten", {
+  expect_true(all(is.finite(ld_by_dim)))
+  expect_true(all(is.finite(ld_total)))
+})
+
+test_that("Summen stimmen mit Gesamtlogdichte \u00fcberein", {
+  expect_equal(rowSums(ld_by_dim), ld_total, tolerance = 1e-12)
+})


### PR DESCRIPTION
## Summary
- Source `ttm_separable` in main script and train it alongside existing models
- Set global seed in `main()` for reproducible results
- Update replicated code snapshot

## Testing
- `Rscript -e 'lintr::lint("main.R")'`
- `Rscript -e 'testthat::test_dir("tests/testthat")'`
- `Rscript main.R` (twice)

------
https://chatgpt.com/codex/tasks/task_e_689c4bd08bbc8333abcd891b88b05bd3