### PR TITLE
Handle NA values when summing evaluation tables

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -11,6 +11,7 @@ source(file.path(root_path, "models/ks_model.R"))
 #'
 #' @param tab data frame mit numerischen Spalten
 #' @param label Bezeichner f\u00fcr die Summenzeile
+#' @details Fehlende Werte in numerischen Spalten werden bei der Summenbildung ignoriert.
 #' @return data frame mit zus\u00e4tzlicher Zeile
 #' @export
 add_sum_row <- function(tab, label = "k") {
@@ -20,7 +21,7 @@ add_sum_row <- function(tab, label = "k") {
     if (nm == "dim") {
       sum_row[[nm]] <- label
     } else if (is.numeric(tab[[nm]])) {
-      sum_row[[nm]] <- sum(tab[[nm]])
+      sum_row[[nm]] <- sum(tab[[nm]], na.rm = TRUE)
     } else {
       sum_row[[nm]] <- NA
     }

--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -233,11 +233,14 @@ struct MapStruct:
     basisF[k], basisG[k], basisH[k]   # callable handles
 ```
 `add_sum_row(tab, label) : (data.frame, string) \to data.frame`
-- **Description:** append a row with columnwise sums for numeric columns.
+- **Description:** append a row with columnwise sums for numeric columns while ignoring `NA` values.
 - **Pseudocode:**
 ```
 function add_sum_row(tab, label)
-    sum_row <- numeric columns summed; 'dim' <- label
+    for each column in tab:
+        if column == "dim": set to label
+        else if numeric: sum column with na.rm = TRUE
+        else: NA
     return rbind(tab, sum_row)
 ```
 

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -647,7 +647,7 @@ for (nm in names(tab)) {
 if (nm == "dim") {
 sum_row[[nm]] <- label
 } else if (is.numeric(tab[[nm]])) {
-sum_row[[nm]] <- sum(tab[[nm]])
+sum_row[[nm]] <- sum(tab[[nm]], na.rm = TRUE)
 } else {
 sum_row[[nm]] <- NA
 }

--- a/tests/testthat/test_add_sum_row.R
+++ b/tests/testthat/test_add_sum_row.R
@@ -1,0 +1,13 @@
+source("../../04_evaluation.R")
+
+# Test that add_sum_row ignores NA values in numeric columns
+
+set.seed(1)
+
+test_that("add_sum_row summiert numerische Spalten trotz NA", {
+  tab <- data.frame(dim = c("1", "2"), a = c(1, NA), b = c(2, 3))
+  res <- add_sum_row(tab, label = "tot")
+  expect_equal(res[3, "a"], 1)
+  expect_equal(res[3, "b"], 5)
+  expect_equal(res[3, "dim"], "tot")
+})


### PR DESCRIPTION
## Summary
- ignore missing values in `add_sum_row` to prevent NA totals
- document NA handling and update algorithm spec
- add regression test for `add_sum_row`

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'`


------
https://chatgpt.com/codex/tasks/task_e_68a46beab6d48328a8291489967c13f9