### PR TITLE
Alle Modelle replizieren und Hilfsskript ausschließen

### DIFF
--- a/main.R
+++ b/main.R
@@ -6,6 +6,7 @@ source("models/trtf_model.R")
 source("models/ks_model.R")
 source("models/ttm_marginal.R")
 source("models/ttm_separable.R")
+source("models/ttm_cross_term.R")
 source("04_evaluation.R")
 source("replicate_code.R")
 

--- a/replicate_code.R
+++ b/replicate_code.R
@@ -3,7 +3,8 @@ extract_sources <- function(main_file = "main.R") {
   pattern <- 'source\\("([^\\"]+)"\\)'
   matches <- regmatches(lines, gregexpr(pattern, lines, perl = TRUE))
   src_files <- unlist(lapply(matches, function(x) if (length(x) > 0) gsub(pattern, "\\1", x)))
-  unique(src_files)
+  src_files <- unique(src_files)
+  src_files[basename(src_files) != "replicate_code.R"]
 }
 
 replicate_code_scripts <- function(main_file = "main.R",

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -632,6 +632,365 @@ stats::sd(v) / sqrt(length(v))
 }
 ### End models/ttm_separable.R ###
 
+### Begin models/ttm_cross_term.R ###
+if (!exists(".standardizeData")) {
+.standardizeData <- function(X) {
+mu <- colMeans(X)
+sigma <- apply(X, 2, sd) + .Machine$double.eps
+X_tilde <- sweep(X, 2, mu, "-")
+X_tilde <- sweep(X_tilde, 2, sigma, "/")
+list(X = X_tilde, mu = mu, sigma = sigma)
+}
+}
+if (!exists(".standardize")) {
+.standardize <- function(S, X) {
+X <- sweep(X, 2, S$mu, "-")
+sweep(X, 2, S$sigma, "/")
+}
+}
+.basis_g_ct <- function(X, deg) {
+if (ncol(X) == 0L) {
+return(matrix(0, nrow = nrow(X), ncol = 0))
+}
+N <- nrow(X)
+out <- matrix(1, N, 1)
+for (j in seq_len(ncol(X))) {
+xj <- X[, j]
+for (d in seq_len(deg)) {
+out <- cbind(out, xj^d)
+}
+}
+out
+}
+.psi_basis_ct <- function(t, xprev, deg_t, deg_x, cross = TRUE) {
+out <- numeric(0)
+for (d in seq_len(deg_t)) {
+out <- c(out, t^d)
+}
+if (length(xprev) > 0) {
+for (j in seq_along(xprev)) {
+for (d in seq_len(deg_x)) {
+out <- c(out, xprev[j]^d)
+}
+}
+if (cross) {
+for (j in seq_along(xprev)) {
+out <- c(out, t * xprev[j])
+}
+}
+}
+out
+}
+.dpsi_dt_ct <- function(t, xprev, deg_t, deg_x, cross = TRUE) {
+out <- numeric(0)
+for (d in seq_len(deg_t)) {
+out <- c(out, d * t^(max(d - 1, 0)))
+}
+if (length(xprev) > 0) {
+for (j in seq_along(xprev)) {
+for (d in seq_len(deg_x)) {
+out <- c(out, 0)
+}
+}
+if (cross) {
+for (j in seq_along(xprev)) {
+out <- c(out, xprev[j])
+}
+}
+}
+out
+}
+.build_Psi_q_ct <- function(xval, xp, nodes, nodes_pow, deg_t, deg_x) {
+Q <- length(nodes)
+m_beta <- deg_t + length(xp) * deg_x + length(xp)
+Psi_q <- matrix(0, Q, m_beta)
+if (deg_t > 0) {
+x_pow <- xval^(seq_len(deg_t))
+Psi_q[, seq_len(deg_t)] <- sweep(nodes_pow, 2, x_pow, "*")
+}
+if (length(xp) > 0) {
+col <- deg_t
+for (j in seq_along(xp)) {
+if (deg_x > 0) {
+xp_pow <- xp[j]^(seq_len(deg_x))
+Psi_q[, col + seq_len(deg_x)] <- matrix(rep(xp_pow, each = Q), Q, deg_x)
+col <- col + deg_x
+}
+}
+t_vec <- nodes * xval
+for (j in seq_along(xp)) {
+Psi_q[, col + j - 1] <- t_vec * xp[j]
+}
+}
+Psi_q
+}
+.gauss_legendre_01_ct <- function(n) {
+if (n <= 0 || n != as.integer(n)) {
+stop("n must be positive integer")
+}
+if (n == 1) {
+return(list(nodes = 0.5, weights = 1))
+}
+i <- seq_len(n - 1)
+b <- i / sqrt(4 * i^2 - 1)
+J <- matrix(0, n, n)
+for (k in i) {
+J[k, k + 1] <- b[k]
+J[k + 1, k] <- b[k]
+}
+e <- eigen(J, symmetric = TRUE)
+x <- (e$values + 1) / 2
+w <- (2 * (e$vectors[1, ]^2)) / 2
+list(nodes = x, weights = w)
+}
+.safe_mclapply_ct <- function(X, FUN, mc.cores, ...) {
+parallel::mclapply(X, function(ix) {
+tryCatch(FUN(ix), error = function(e) e)
+}, mc.cores = mc.cores, mc.set.seed = FALSE, mc.preschedule = TRUE, ...)
+}
+.is_coeffs_ok <- function(x) is.list(x) && is.numeric(x$alpha) && is.numeric(x$beta)
+.is_predchunk_ok <- function(x) is.list(x) && is.numeric(x$Z_col) && is.numeric(x$LJ_col)
+.zero_coeffs_ct <- function(k, X_tr_std, degree_g, degree_t) {
+N <- nrow(X_tr_std)
+Xprev <- if (k > 1) X_tr_std[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
+m_alpha <- ncol(.basis_g_ct(Xprev, degree_g))
+xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
+m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE))
+list(alpha = if (m_alpha > 0) rep(0, m_alpha) else numeric(0),
+beta  = rep(0, m_beta))
+}
+.zero_predchunk_ct <- function(N, sigma_k) {
+list(Z_col = rep(0, N), LJ_col = rep(-log(sigma_k), N))
+}
+.NLL_set_ct <- function(S, X) {
+mean(-rowSums(predict(S, X, "logdensity_by_dim")))
+}
+.SE_set_ct <- function(S, X) {
+v <- rowSums(-predict(S, X, "logdensity_by_dim"))
+stats::sd(v) / sqrt(length(v))
+}
+.logJacDiag_ct <- function(S, x) {
+Xs <- .standardize(S, matrix(x, nrow = 1))
+K <- length(x)
+out <- numeric(K)
+for (k in seq_len(K)) {
+xprev <- if (k > 1) Xs[1, 1:(k - 1)] else numeric(0)
+psi <- .psi_basis_ct(Xs[1, k], xprev, S$degree_t, S$degree_g, TRUE)
+beta <- S$coeffs[[k]]$beta
+out[k] <- sum(beta * psi) - log(S$sigma[k])
+}
+out
+}
+.forwardKLLoss_ct <- function(S, X) {
+X <- as.matrix(X)
+K <- ncol(X)
+LD <- predict(S, X, "logdensity_by_dim")
+mean(-rowSums(LD) - 0.5 * K * log(2 * pi))
+}
+trainCrossTermMap <- function(X_or_path, degree_g = 2, degree_t = 2,
+lambda = 1e-3, batch_n = NULL, Q = NULL,
+eps = 1e-6, clip = 20) {
+set.seed(42)
+S_in <- if (is.character(X_or_path)) readRDS(X_or_path) else X_or_path
+stopifnot(is.list(S_in))
+X_tr <- S_in$X_tr
+X_val <- S_in$X_val
+X_te  <- S_in$X_te
+time_train <- system.time({
+std <- .standardizeData(X_tr)
+X_tr_std <- std$X
+mu <- std$mu
+sigma <- std$sigma
+N <- nrow(X_tr_std)
+K <- ncol(X_tr_std)
+Q_use <- if (is.null(Q)) min(12, 4 + 2 * degree_t) else Q
+batch_use <- if (is.null(batch_n)) min(N, max(256L, floor(65536 / max(1L, Q_use)))) else min(N, batch_n)
+quad <- .gauss_legendre_01_ct(Q_use)
+nodes <- quad$nodes
+weights <- quad$weights
+nodes_pow <- outer(nodes, seq_len(degree_t), `^`)
+fit_k <- function(k) {
+Xprev <- if (k > 1) X_tr_std[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
+xk <- X_tr_std[, k]
+Phi <- .basis_g_ct(Xprev, degree_g)
+m_alpha <- ncol(Phi)
+xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
+m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE))
+loss_grad <- function(alpha, beta) {
+S_sq_sum <- 0
+term_sum <- 0
+grad_alpha <- if (m_alpha > 0) rep(0, m_alpha) else numeric(0)
+grad_beta <- rep(0, m_beta)
+for (i0 in seq(1, N, by = batch_use)) {
+idx <- i0:min(i0 + batch_use - 1, N)
+Phi_blk <- if (m_alpha > 0) Phi[idx, , drop = FALSE] else NULL
+Xprev_blk <- if (k > 1) Xprev[idx, , drop = FALSE] else matrix(0, length(idx), 0)
+xk_blk <- xk[idx]
+for (b in seq_along(idx)) {
+xp <- if (k > 1) Xprev_blk[b, ] else numeric(0)
+xval <- xk_blk[b]
+Psi_q <- .build_Psi_q_ct(xval, xp, nodes, nodes_pow, degree_t, degree_g)
+V <- Psi_q %*% beta
+m <- max(V)
+v_shift <- V - m
+ev_full <- exp(v_shift)
+ev_clip <- exp(pmax(v_shift, -clip))
+s <- sum(weights * ev_clip)
+I_i <- xval * exp(m) * s
+dI_i <- xval * as.vector(t(Psi_q) %*% (weights * ev_full))
+psi_x <- .psi_basis_ct(xval, xp, degree_t, degree_g, TRUE)
+S_i <- if (m_alpha > 0) sum(Phi_blk[b, ] * alpha) + I_i else I_i
+S_sq_sum <- S_sq_sum + S_i^2
+if (m_alpha > 0) grad_alpha <- grad_alpha + S_i * Phi_blk[b, ]
+grad_beta <- grad_beta + S_i * dI_i - psi_x
+term_sum <- term_sum + sum(psi_x * beta)
+}
+}
+loss <- 0.5 * S_sq_sum / N - term_sum / N +
+0.5 * lambda * (sum(alpha^2) + sum(beta^2))
+grad_alpha_out <- if (m_alpha > 0) grad_alpha / N + lambda * alpha else numeric(0)
+grad_beta_out <- grad_beta / N + lambda * beta
+list(loss = loss, grad = c(grad_alpha_out, grad_beta_out))
+}
+cache <- new.env(parent = emptyenv())
+fn <- function(theta) {
+alpha <- if (m_alpha > 0) theta[seq_len(m_alpha)] else numeric(0)
+beta <- theta[(m_alpha + 1):length(theta)]
+res <- loss_grad(alpha, beta)
+cache$grad <- res$grad
+res$loss
+}
+gr <- function(theta) {
+if (!is.null(cache$grad)) {
+g <- cache$grad
+cache$grad <- NULL
+return(g)
+}
+alpha <- if (m_alpha > 0) theta[seq_len(m_alpha)] else numeric(0)
+beta <- theta[(m_alpha + 1):length(theta)]
+loss_grad(alpha, beta)$grad
+}
+theta0 <- rep(0, m_alpha + m_beta)
+opt <- optim(theta0, fn, gr, method = "L-BFGS-B", lower = -Inf, upper = Inf)
+alpha_hat <- if (m_alpha > 0) opt$par[seq_len(m_alpha)] else numeric(0)
+beta_hat <- opt$par[(m_alpha + 1):length(opt$par)]
+list(alpha = alpha_hat, beta = beta_hat)
+}
+res <- .safe_mclapply_ct(seq_len(K), fit_k,
+mc.cores = min(getOption("mc.cores", 10L), K))
+for (k in seq_len(K)) {
+if (!.is_coeffs_ok(res[[k]])) {
+r2 <- tryCatch(fit_k(k), error = function(e) e)
+if (!.is_coeffs_ok(r2)) {
+r2 <- .zero_coeffs_ct(k, X_tr_std, degree_g, degree_t)
+}
+res[[k]] <- r2
+}
+}
+coeffs <- res
+stopifnot(length(coeffs) == K,
+all(vapply(coeffs, .is_coeffs_ok, logical(1))) )
+S_map <- list(
+mu = mu,
+sigma = sigma,
+degree_g = degree_g,
+degree_t = degree_t,
+coeffs = coeffs,
+Q = Q_use,
+nodes = nodes,
+weights = weights,
+nodes_pow = nodes_pow,
+quad_nodes_ct = nodes,
+quad_weights_ct = weights,
+quad_nodes_pow_ct = nodes_pow,
+clip = clip,
+order = seq_len(K)
+)
+class(S_map) <- "ttm_cross_term"
+})[["elapsed"]]
+time_pred <- system.time({
+predict(S_map, X_te, "logdensity_by_dim")
+})[["elapsed"]]
+list(
+S = S_map,
+NLL_train = .NLL_set_ct(S_map, X_tr),
+NLL_val = .NLL_set_ct(S_map, X_val),
+NLL_test = .NLL_set_ct(S_map, X_te),
+stderr_test = .SE_set_ct(S_map, X_te),
+time_train = time_train,
+time_pred = time_pred
+)
+}
+predict.ttm_cross_term <- function(object, newdata,
+type = c("logdensity_by_dim", "logdensity"),
+batch_n = NULL) {
+type <- tryCatch(match.arg(type), error = function(e) stop("unknown type"))
+Xs <- .standardize(object, newdata)
+N <- nrow(Xs)
+K <- ncol(Xs)
+batch_use <- if (is.null(batch_n)) min(N, max(256L, floor(65536 / max(1L, object$Q)))) else min(N, batch_n)
+nodes <- object$quad_nodes_ct
+weights <- object$quad_weights_ct
+nodes_pow <- object$quad_nodes_pow_ct
+C <- -0.5 * log(2 * pi)
+chunk_fun <- function(k) {
+Xprev <- if (k > 1) Xs[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
+xk <- Xs[, k]
+Phi <- .basis_g_ct(Xprev, object$degree_g)
+m_alpha <- ncol(Phi)
+alpha <- object$coeffs[[k]]$alpha
+beta <- object$coeffs[[k]]$beta
+xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
+psi_len <- length(.psi_basis_ct(Xs[1, k], xprev_first,
+object$degree_t, object$degree_g, TRUE))
+stopifnot(length(beta) == psi_len)
+Z_col <- numeric(N)
+LJ_col <- numeric(N)
+for (i0 in seq(1, N, by = batch_use)) {
+idx <- i0:min(i0 + batch_use - 1, N)
+Phi_blk <- if (m_alpha > 0) Phi[idx, , drop = FALSE] else NULL
+Xprev_blk <- if (k > 1) Xprev[idx, , drop = FALSE] else matrix(0, length(idx), 0)
+xk_blk <- xk[idx]
+for (b in seq_along(idx)) {
+xp <- if (k > 1) Xprev_blk[b, ] else numeric(0)
+xval <- xk_blk[b]
+Psi_q <- .build_Psi_q_ct(xval, xp, nodes, nodes_pow, object$degree_t, object$degree_g)
+V <- Psi_q %*% beta
+m <- max(V)
+v_shift <- V - m
+ev <- exp(pmax(v_shift, -object$clip))
+s <- sum(weights * ev)
+I_i <- xval * exp(m) * s
+psi_x <- .psi_basis_ct(xval, xp, object$degree_t, object$degree_g, TRUE)
+Z_col[idx[b]] <- if (m_alpha > 0) sum(Phi_blk[b, ] * alpha) + I_i else I_i
+LJ_col[idx[b]] <- sum(beta * psi_x) - log(object$sigma[k])
+}
+}
+list(Z_col = Z_col, LJ_col = LJ_col)
+}
+res <- .safe_mclapply_ct(seq_len(K), chunk_fun,
+mc.cores = min(getOption("mc.cores", 10L), K))
+for (k in seq_len(K)) {
+if (!.is_predchunk_ok(res[[k]])) {
+r2 <- tryCatch(chunk_fun(k), error = function(e) e)
+if (!.is_predchunk_ok(r2)) {
+r2 <- .zero_predchunk_ct(N, object$sigma[k])
+r2$Z_col <- Xs[, k]
+}
+res[[k]] <- r2
+}
+}
+Z <- do.call(cbind, lapply(res, `[[`, "Z_col"))
+LJ <- do.call(cbind, lapply(res, `[[`, "LJ_col"))
+LD <- (-0.5) * (Z^2) + C + LJ
+if (type == "logdensity_by_dim") {
+LD
+} else {
+rowSums(LD)
+}
+}
+### End models/ttm_cross_term.R ###
+
 ### Begin 04_evaluation.R ###
 root_path <- getwd()
 if (basename(root_path) == "testthat") {
@@ -775,58 +1134,6 @@ tab
 }
 ### End 04_evaluation.R ###
 
-### Begin replicate_code.R ###
-extract_sources <- function(main_file = "main.R") {
-lines <- readLines(main_file, warn = FALSE)
-pattern <- 'source\\("([^\\"]+)"\\)'
-matches <- regmatches(lines, gregexpr(pattern, lines, perl = TRUE))
-src_files <- unlist(lapply(matches, function(x) if (length(x) > 0) gsub(pattern, "\\1", x)))
-unique(src_files)
-}
-replicate_code_scripts <- function(main_file = "main.R",
-outfile = "replicated_code.txt",
-env = parent.frame()) {
-src_files <- extract_sources(main_file)
-output_lines <- character()
-for (f in src_files) {
-if (file.exists(f)) {
-lines <- readLines(f, warn = FALSE)
-lines <- sub("
-lines <- trimws(lines)
-lines <- lines[nchar(lines) > 0]
-output_lines <- c(output_lines,
-paste0("
-lines,
-paste0("
-"")
-}
-}
-if (file.exists(main_file)) {
-lines <- readLines(main_file, warn = FALSE)
-lines <- sub("
-lines <- trimws(lines)
-lines <- lines[nchar(lines) > 0]
-output_lines <- c(output_lines,
-paste0("
-lines,
-paste0("
-"")
-}
-if (exists("results_table", envir = env)) {
-tab <- get("results_table", envir = env)
-tab_lines <- capture.output(print(tab))
-output_lines <- c(output_lines,
-"
-tab_lines,
-"")
-}
-writeLines(output_lines, outfile)
-}
-if (sys.nframe() == 0L) {
-replicate_code_scripts()
-}
-### End replicate_code.R ###
-
 ### Begin main.R ###
 source("00_globals.R")
 source("01_data_generation.R")
@@ -836,6 +1143,7 @@ source("models/trtf_model.R")
 source("models/ks_model.R")
 source("models/ttm_marginal.R")
 source("models/ttm_separable.R")
+source("models/ttm_cross_term.R")
 source("04_evaluation.R")
 source("replicate_code.R")
 n <- 50
@@ -872,16 +1180,16 @@ replicate_code_scripts("main.R", "replicated_code.txt", env = globalenv())
 ### End main.R ###
 
 ### Final results table ###
-  dim distribution         true Random Forest           ks Marginal Map
-1   1         norm  1.45 ± 0.29   1.45 ± 0.28  1.49 ± 0.26  1.47 ± 0.25
-2   2          exp  1.83 ± 1.13   1.24 ± 0.67  1.80 ± 1.44  2.95 ± 0.22
-3   3         beta -0.54 ± 1.54   0.05 ± 0.49 -0.10 ± 0.33  0.33 ± 0.31
-4   4        gamma  1.36 ± 0.71   1.32 ± 0.43  2.35 ± 1.70  2.81 ± 0.06
-5   k          SUM  4.10 ± 0.64   4.06 ± 0.98  5.54 ± 3.14  7.57 ± 0.62
+  dim distribution         true Random Forest            ks Marginal Map
+1   1         norm  1.55 ± 0.47   1.62 ± 0.42   1.60 ± 0.46  1.57 ± 0.38
+2   2          exp  1.65 ± 0.63   2.73 ± 1.00   2.06 ± 0.62  3.30 ± 0.01
+3   3         beta -0.75 ± 1.23  -0.12 ± 0.52  -0.15 ± 0.70  0.41 ± 0.22
+4   4        gamma  2.93 ± 1.97   2.72 ± 1.98 10.90 ± 11.98  3.32 ± 1.45
+5   k          SUM  5.38 ± 2.03   6.95 ± 3.02 14.40 ± 12.48  8.59 ± 1.77
   Separable Map Cross-term Map
-1   1.45 ± 0.29    1.45 ± 0.29
-2   1.56 ± 0.69    2.66 ± 0.62
-3  -0.02 ± 0.39   -4.48 ± 4.71
-4   2.25 ± 0.84    2.09 ± 0.36
-5   5.26 ± 1.69    1.72 ± 3.96
+1   1.55 ± 0.47    1.50 ± 0.46
+2   1.91 ± 0.65    0.54 ± 1.72
+3  -0.00 ± 0.63    0.77 ± 7.75
+4   3.36 ± 2.68    1.58 ± 0.34
+5   6.81 ± 3.36    4.39 ± 8.36
 


### PR DESCRIPTION
## Zusammenfassung
- binde `ttm_cross_term.R` direkt in `main.R` ein, damit alle Modellskripte repliziert werden.
- filtere `replicate_code.R` in `replicate_code.R` aus, sodass es nicht mehr in `replicated_code.txt` aufgenommen wird.
- aktualisiere `replicated_code.txt` durch erneutes Ausführen von `main.R`.

## Tests
- `Rscript main.R`
- `Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_68a5607adacc83289db91b1222b5c094