### PR TITLE
Kernel-Smoothing aus Evaluationspipeline entfernen

### DIFF
--- a/04_evaluation.R
+++ b/04_evaluation.R
@@ -91,8 +91,6 @@ calc_loglik_tables <- function(models, config, X_te) {
     ll_true[, k] <- -ll_vec
   }
   ll_trtf <- -predict(models$trtf, X_te, type = "logdensity_by_dim")
-
-  ll_ks   <- -predict(models$ks,  X_te, type = "logdensity_by_dim")
   ll_true_joint <- - true_joint_logdensity_by_dim(config, X_te)
 
   if (!is.null(models$ttm)) {

--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -276,7 +276,6 @@ function add_sum_row(tab, label)
 function calc_loglik_tables(models, config, X_te)
     ll_true <- -predict_TRUE(models.true, X_te)
     ll_trtf <- -predict(models.trtf, X_te)
-    ll_ks   <- -predict(models.ks,   X_te)
     ll_true_joint <- -true_joint_logdensity_by_dim(config, X_te)
     if models.ttm exists:
         ll_ttm <- -predict(models.ttm$S, X_te)
@@ -305,13 +304,11 @@ function calc_loglik_tables(models, config, X_te)
     se_true_joint <- apply(ll_true_joint,2,stderr)
     se_sum_true_joint <- sd(rowSums(ll_true_joint)) / sqrt(nrow(ll_true_joint))
     mean_trtf <- colMeans(ll_trtf); se_trtf <- apply(ll_trtf,2,stderr)
-    mean_ks   <- colMeans(ll_ks);   se_ks   <- apply(ll_ks,2,stderr)
     fmt(x,se) = sprintf("%.2f ± %.2f", round(x,2), round(2*se,2))
     tab <- data.frame(dim, distribution,
                       true = fmt(mean_true, se_true),
                       true_joint = fmt(mean_true_joint, se_true_joint),
                       trtf = fmt(mean_trtf, se_trtf),
-                      ks   = fmt(mean_ks,   se_ks),
                       ttm  = fmt(mean_ttm,  se_ttm),
                       ttm_sep = fmt(mean_sep, se_sep),
                       ttm_cross = fmt(mean_cross, se_cross))
@@ -319,7 +316,6 @@ function calc_loglik_tables(models, config, X_te)
                           true=fmt(sum(mean_true), se_sum_true),
                           true_joint=fmt(sum(mean_true_joint), se_sum_true_joint),
                           trtf=fmt(sum(mean_trtf), se_sum_trtf),
-                          ks  =fmt(sum(mean_ks),   se_sum_ks),
                           ttm =fmt(sum(mean_ttm),  se_sum_ttm),
                           ttm_sep=fmt(sum(mean_sep), se_sum_sep),
                           ttm_cross=fmt(sum(mean_cross), se_sum_cross))

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -1091,10 +1091,7 @@ models$true$theta[[k]])
 ll_true[, k] <- -ll_vec
 }
 ll_trtf <- -predict(models$trtf, X_te, type = "logdensity_by_dim")
-
-ll_ks   <- -predict(models$ks,  X_te, type = "logdensity_by_dim")
 ll_true_joint <- - true_joint_logdensity_by_dim(config, X_te)
-
 if (!is.null(models$ttm)) {
 ll_ttm <- -predict(models$ttm$S, X_te, type = "logdensity_by_dim")
 mean_ttm <- colMeans(ll_ttm)
@@ -1226,18 +1223,16 @@ replicate_code_scripts("main.R", "replicated_code.txt", env = globalenv())
 ### End main.R ###
 
 ### Final results table ###
-
-  dim distribution True (marginal) True (Joint) Random Forest            ks
-1   1         norm     1.55 ± 0.47  1.54 ± 0.48   1.62 ± 0.42   1.60 ± 0.46
-2   2          exp     1.65 ± 0.63  1.65 ± 0.87   2.73 ± 1.00   2.06 ± 0.62
-3   3         beta    -0.75 ± 1.23 -1.23 ± 1.69  -0.12 ± 0.52  -0.15 ± 0.70
-4   4        gamma     2.93 ± 1.97  2.25 ± 1.47   2.72 ± 1.98 10.90 ± 11.98
-5   k          SUM     5.38 ± 2.03  4.21 ± 2.17   6.95 ± 3.02 14.40 ± 12.48
-  Marginal Map Separable Map Cross-term Map
-1  1.57 ± 0.38   1.55 ± 0.47    1.50 ± 0.46
-2  3.30 ± 0.01   1.91 ± 0.65    0.54 ± 1.72
-3  0.41 ± 0.22  -0.00 ± 0.63    0.77 ± 7.75
-4  3.32 ± 1.45   3.36 ± 2.68    1.58 ± 0.34
-5  8.59 ± 1.77   6.81 ± 3.36    4.39 ± 8.36
-
+  dim distribution True (marginal) True (Joint) Random Forest Marginal Map
+1   1         norm     1.55 ± 0.47  1.54 ± 0.48   1.62 ± 0.42  1.57 ± 0.38
+2   2          exp     1.65 ± 0.63  1.65 ± 0.87   2.73 ± 1.00  3.30 ± 0.01
+3   3         beta    -0.75 ± 1.23 -1.23 ± 1.69  -0.12 ± 0.52  0.41 ± 0.22
+4   4        gamma     2.93 ± 1.97  2.25 ± 1.47   2.72 ± 1.98  3.32 ± 1.45
+5   k          SUM     5.38 ± 2.03  4.21 ± 2.17   6.95 ± 3.02  8.59 ± 1.77
+  Separable Map Cross-term Map
+1   1.55 ± 0.47    1.50 ± 0.46
+2   1.91 ± 0.65    0.54 ± 1.72
+3  -0.00 ± 0.63    0.77 ± 7.75
+4   3.36 ± 2.68    1.58 ± 0.34
+5   6.81 ± 3.36    4.39 ± 8.36
 


### PR DESCRIPTION
## Zusammenfassung
- Entferne Kernel-Smoothing aus `calc_loglik_tables`
- Passe `ALGORITHM_SPEC.md` an ohne KS-Spalte
- Aktualisiere `replicated_code.txt` nach Ausführung von `main.R`

## Testen
- `timeout 120 R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` (Abbruch: Execution halted)
- `Rscript main.R`

------
https://chatgpt.com/codex/tasks/task_e_68a57ba047088328ab85212f74b26c08