### PR TITLE
Erweitere Kreuzbasis um höhere Grade

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -40,7 +40,7 @@ predict.ttm_separable(S, X, type)
 trainCrossTermMap(X_or_path)
 predict.ttm_cross_term(S, X, type)
 forwardKLLoss_ct(S, X) = mean(-rowSums(predict(S,X,"logdensity_by_dim")) - 0.5*K*log(2*pi))
-- uses polynomial bases with optional cross terms
+- uses polynomial bases with cross terms t^r x_j^s (degrees deg_t_cross, deg_x_cross)
 - Gauss-Legendre quadrature on [0,1]
 - analytic derivative basis `.dpsi_dt_ct` for monotonicity checks
 - optimization of forward KL via L-BFGS-B

--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -37,7 +37,7 @@ predict.ttm_separable(S, X, type)
 
 ```
 ########  TTM CORE (cross term) ########
-trainCrossTermMap(X_or_path)
+trainCrossTermMap(X_or_path, warmstart_from_separable=FALSE)
 predict.ttm_cross_term(S, X, type)
 forwardKLLoss_ct(S, X) = mean(-rowSums(predict(S,X,"logdensity_by_dim")) - 0.5*K*log(2*pi))
 - uses polynomial bases with cross terms t^r x_j^s (degrees deg_t_cross, deg_x_cross)
@@ -46,6 +46,7 @@ forwardKLLoss_ct(S, X) = mean(-rowSums(predict(S,X,"logdensity_by_dim")) - 0.5*K
 - optimization of forward KL via L-BFGS-B
 - chunked training and prediction with stable log-sum-exp quadrature, parallelized over dimensions
 - robuste Parallelisierung mit sequentiellem Retry und Null-Koeffizienten-Fallback
+- optionaler Warm-Start der g_k-Koeffizienten aus der separablen Map
 ######################################
 ```
 

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -700,7 +700,8 @@ m_alpha <- ncol(.basis_g_ct(Xprev, degree_g))
 xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
 m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE, degree_t_cross, degree_x_cross))
 list(alpha = if (m_alpha > 0) rep(0, m_alpha) else numeric(0),
-beta  = rep(0, m_beta))
+beta  = rep(0, m_beta),
+convergence = NA_real_)
 }
 .zero_predchunk_ct <- function(N, sigma_k) {
 list(Z_col = rep(0, N), LJ_col = rep(-log(sigma_k), N))
@@ -732,13 +733,23 @@ mean(-rowSums(LD) - 0.5 * K * log(2 * pi))
 }
 trainCrossTermMap <- function(X_or_path, degree_g = 2, degree_t = 2, degree_t_cross = 1, degree_x_cross = 1,
 lambda = 1e-3, batch_n = NULL, Q = NULL,
-eps = 1e-6, clip = 20) {
+eps = 1e-6, clip = 20,
+alpha_init_list = NULL, warmstart_from_separable = FALSE,
+sep_degree_g = NULL, sep_lambda = 1e-3) {
 set.seed(42)
 S_in <- if (is.character(X_or_path)) readRDS(X_or_path) else X_or_path
 stopifnot(is.list(S_in))
 X_tr <- S_in$X_tr
 X_val <- S_in$X_val
 X_te  <- S_in$X_te
+if (is.null(alpha_init_list) && warmstart_from_separable) {
+if (!exists("trainSeparableMap")) {
+stop("trainSeparableMap not found for warm start")
+}
+sep_deg <- if (is.null(sep_degree_g)) degree_g else sep_degree_g
+fit_sep <- trainSeparableMap(S_in, degree_g = sep_deg, lambda = sep_lambda)
+alpha_init_list <- lapply(fit_sep$S$coeffs, `[[`, "c_non")
+}
 time_train <- system.time({
 std <- .standardizeData(X_tr)
 X_tr_std <- std$X
@@ -746,6 +757,9 @@ mu <- std$mu
 sigma <- std$sigma
 N <- nrow(X_tr_std)
 K <- ncol(X_tr_std)
+if (!is.null(alpha_init_list)) {
+stopifnot(length(alpha_init_list) == K)
+}
 degree_t_max <- max(degree_t, degree_t_cross)
 Q_use <- if (is.null(Q)) min(12, 4 + 2 * degree_t_max) else Q
 batch_use <- if (is.null(batch_n)) min(N, max(256L, floor(65536 / max(1L, Q_use)))) else min(N, batch_n)
@@ -760,6 +774,16 @@ Phi <- .basis_g_ct(Xprev, degree_g)
 m_alpha <- ncol(Phi)
 xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
 m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE, degree_t_cross, degree_x_cross))
+alpha_start <- if (m_alpha > 0) {
+if (is.null(alpha_init_list)) {
+rep(0, m_alpha)
+} else {
+ai <- alpha_init_list[[k]]
+if (length(ai) != m_alpha) rep(0, m_alpha) else ai
+}
+} else {
+numeric(0)
+}
 loss_grad <- function(alpha, beta) {
 S_sq_sum <- 0
 term_sum <- 0
@@ -813,11 +837,11 @@ alpha <- if (m_alpha > 0) theta[seq_len(m_alpha)] else numeric(0)
 beta <- theta[(m_alpha + 1):length(theta)]
 loss_grad(alpha, beta)$grad
 }
-theta0 <- rep(0, m_alpha + m_beta)
+theta0 <- c(alpha_start, rep(0, m_beta))
 opt <- optim(theta0, fn, gr, method = "L-BFGS-B", lower = -Inf, upper = Inf)
 alpha_hat <- if (m_alpha > 0) opt$par[seq_len(m_alpha)] else numeric(0)
 beta_hat <- opt$par[(m_alpha + 1):length(opt$par)]
-list(alpha = alpha_hat, beta = beta_hat)
+list(alpha = alpha_hat, beta = beta_hat, convergence = opt$convergence)
 }
 res <- .safe_mclapply_ct(seq_len(K), fit_k,
 mc.cores = min(getOption("mc.cores", 10L), K))

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -604,42 +604,64 @@ out <- cbind(out, xj^d)
 }
 out
 }
-.psi_basis_ct <- function(t, xprev, deg_t, deg_x, cross = TRUE) {
+.psi_basis_ct <- function(t, xprev, deg_t, deg_x, cross = TRUE,
+deg_t_cross = 1, deg_x_cross = 1) {
 out <- numeric(0)
+if (deg_t > 0) {
 for (d in seq_len(deg_t)) {
 out <- c(out, t^d)
 }
+}
 if (cross && length(xprev) > 0) {
 for (j in seq_along(xprev)) {
-out <- c(out, t * xprev[j])
+for (r in seq_len(deg_t_cross)) {
+for (s in seq_len(deg_x_cross)) {
+out <- c(out, t^r * xprev[j]^s)
+}
+}
 }
 }
 out
 }
-.dpsi_dt_ct <- function(t, xprev, deg_t, deg_x, cross = TRUE) {
+.dpsi_dt_ct <- function(t, xprev, deg_t, deg_x, cross = TRUE,
+deg_t_cross = 1, deg_x_cross = 1) {
 out <- numeric(0)
+if (deg_t > 0) {
 for (d in seq_len(deg_t)) {
 out <- c(out, d * t^(max(d - 1, 0)))
 }
+}
 if (cross && length(xprev) > 0) {
 for (j in seq_along(xprev)) {
-out <- c(out, xprev[j])
+for (r in seq_len(deg_t_cross)) {
+for (s in seq_len(deg_x_cross)) {
+out <- c(out, r * t^(max(r - 1, 0)) * xprev[j]^s)
+}
+}
 }
 }
 out
 }
-.build_Psi_q_ct <- function(xval, xp, nodes, nodes_pow, deg_t, deg_x) {
+.build_Psi_q_ct <- function(xval, xp, nodes, nodes_pow, deg_t, deg_x,
+deg_t_cross = 1, deg_x_cross = 1) {
 Q <- length(nodes)
-m_beta <- deg_t + length(xp)
+m_beta <- deg_t + length(xp) * deg_t_cross * deg_x_cross
 Psi_q <- matrix(0, Q, m_beta)
 if (deg_t > 0) {
 x_pow <- xval^(seq_len(deg_t))
-Psi_q[, seq_len(deg_t)] <- sweep(nodes_pow, 2, x_pow, "*")
+Psi_q[, seq_len(deg_t)] <- sweep(nodes_pow[, seq_len(deg_t), drop = FALSE], 2, x_pow, "*")
 }
 if (length(xp) > 0) {
-t_vec <- nodes * xval
+col <- deg_t
+x_pow_cross <- xval^(seq_len(deg_t_cross))
+xp_pows <- lapply(xp, function(xj) xj^(seq_len(deg_x_cross)))
 for (j in seq_along(xp)) {
-Psi_q[, deg_t + j] <- t_vec * xp[j]
+for (r in seq_len(deg_t_cross)) {
+for (s in seq_len(deg_x_cross)) {
+col <- col + 1
+Psi_q[, col] <- nodes_pow[, r] * x_pow_cross[r] * xp_pows[[j]][s]
+}
+}
 }
 }
 Psi_q
@@ -670,12 +692,13 @@ tryCatch(FUN(ix), error = function(e) e)
 }
 .is_coeffs_ok <- function(x) is.list(x) && is.numeric(x$alpha) && is.numeric(x$beta)
 .is_predchunk_ok <- function(x) is.list(x) && is.numeric(x$Z_col) && is.numeric(x$LJ_col)
-.zero_coeffs_ct <- function(k, X_tr_std, degree_g, degree_t) {
+.zero_coeffs_ct <- function(k, X_tr_std, degree_g, degree_t,
+degree_t_cross, degree_x_cross) {
 N <- nrow(X_tr_std)
 Xprev <- if (k > 1) X_tr_std[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
 m_alpha <- ncol(.basis_g_ct(Xprev, degree_g))
 xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
-m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE))
+m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE, degree_t_cross, degree_x_cross))
 list(alpha = if (m_alpha > 0) rep(0, m_alpha) else numeric(0),
 beta  = rep(0, m_beta))
 }
@@ -695,7 +718,7 @@ K <- length(x)
 out <- numeric(K)
 for (k in seq_len(K)) {
 xprev <- if (k > 1) Xs[1, 1:(k - 1)] else numeric(0)
-psi <- .psi_basis_ct(Xs[1, k], xprev, S$degree_t, S$degree_g, TRUE)
+psi <- .psi_basis_ct(Xs[1, k], xprev, S$degree_t, S$degree_g, TRUE, S$degree_t_cross, S$degree_x_cross)
 beta <- S$coeffs[[k]]$beta
 out[k] <- sum(beta * psi) - log(S$sigma[k])
 }
@@ -707,7 +730,7 @@ K <- ncol(X)
 LD <- predict(S, X, "logdensity_by_dim")
 mean(-rowSums(LD) - 0.5 * K * log(2 * pi))
 }
-trainCrossTermMap <- function(X_or_path, degree_g = 2, degree_t = 2,
+trainCrossTermMap <- function(X_or_path, degree_g = 2, degree_t = 2, degree_t_cross = 1, degree_x_cross = 1,
 lambda = 1e-3, batch_n = NULL, Q = NULL,
 eps = 1e-6, clip = 20) {
 set.seed(42)
@@ -723,19 +746,20 @@ mu <- std$mu
 sigma <- std$sigma
 N <- nrow(X_tr_std)
 K <- ncol(X_tr_std)
-Q_use <- if (is.null(Q)) min(12, 4 + 2 * degree_t) else Q
+degree_t_max <- max(degree_t, degree_t_cross)
+Q_use <- if (is.null(Q)) min(12, 4 + 2 * degree_t_max) else Q
 batch_use <- if (is.null(batch_n)) min(N, max(256L, floor(65536 / max(1L, Q_use)))) else min(N, batch_n)
 quad <- .gauss_legendre_01_ct(Q_use)
 nodes <- quad$nodes
 weights <- quad$weights
-nodes_pow <- outer(nodes, seq_len(degree_t), `^`)
+nodes_pow <- outer(nodes, seq_len(degree_t_max), `^`)
 fit_k <- function(k) {
 Xprev <- if (k > 1) X_tr_std[, 1:(k - 1), drop = FALSE] else matrix(0, N, 0)
 xk <- X_tr_std[, k]
 Phi <- .basis_g_ct(Xprev, degree_g)
 m_alpha <- ncol(Phi)
 xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
-m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE))
+m_beta <- length(.psi_basis_ct(0, xprev_first, degree_t, degree_g, TRUE, degree_t_cross, degree_x_cross))
 loss_grad <- function(alpha, beta) {
 S_sq_sum <- 0
 term_sum <- 0
@@ -749,7 +773,7 @@ xk_blk <- xk[idx]
 for (b in seq_along(idx)) {
 xp <- if (k > 1) Xprev_blk[b, ] else numeric(0)
 xval <- xk_blk[b]
-Psi_q <- .build_Psi_q_ct(xval, xp, nodes, nodes_pow, degree_t, degree_g)
+Psi_q <- .build_Psi_q_ct(xval, xp, nodes, nodes_pow, degree_t, degree_g, degree_t_cross, degree_x_cross)
 V <- Psi_q %*% beta
 m <- max(V)
 v_shift <- V - m
@@ -757,7 +781,7 @@ ev <- exp(pmax(v_shift, -clip))
 s  <- sum(weights * ev)
 I_i  <- xval * exp(m) * s
 dI_i <- xval * exp(m) * as.vector(t(Psi_q) %*% (weights * ev))
-psi_x <- .psi_basis_ct(xval, xp, degree_t, degree_g, TRUE)
+psi_x <- .psi_basis_ct(xval, xp, degree_t, degree_g, TRUE, degree_t_cross, degree_x_cross)
 S_i <- if (m_alpha > 0) sum(Phi_blk[b, ] * alpha) + I_i else I_i
 S_sq_sum <- S_sq_sum + S_i^2
 if (m_alpha > 0) grad_alpha <- grad_alpha + S_i * Phi_blk[b, ]
@@ -801,7 +825,7 @@ for (k in seq_len(K)) {
 if (!.is_coeffs_ok(res[[k]])) {
 r2 <- tryCatch(fit_k(k), error = function(e) e)
 if (!.is_coeffs_ok(r2)) {
-r2 <- .zero_coeffs_ct(k, X_tr_std, degree_g, degree_t)
+r2 <- .zero_coeffs_ct(k, X_tr_std, degree_g, degree_t, degree_t_cross, degree_x_cross)
 }
 res[[k]] <- r2
 }
@@ -814,6 +838,8 @@ mu = mu,
 sigma = sigma,
 degree_g = degree_g,
 degree_t = degree_t,
+degree_t_cross = degree_t_cross,
+degree_x_cross = degree_x_cross,
 coeffs = coeffs,
 Q = Q_use,
 nodes = nodes,
@@ -861,7 +887,7 @@ alpha <- object$coeffs[[k]]$alpha
 beta <- object$coeffs[[k]]$beta
 xprev_first <- if (k > 1) Xprev[1, , drop = TRUE] else numeric(0)
 psi_len <- length(.psi_basis_ct(Xs[1, k], xprev_first,
-object$degree_t, object$degree_g, TRUE))
+object$degree_t, object$degree_g, TRUE, object$degree_t_cross, object$degree_x_cross))
 stopifnot(length(beta) == psi_len)
 Z_col <- numeric(N)
 LJ_col <- numeric(N)
@@ -873,14 +899,14 @@ xk_blk <- xk[idx]
 for (b in seq_along(idx)) {
 xp <- if (k > 1) Xprev_blk[b, ] else numeric(0)
 xval <- xk_blk[b]
-Psi_q <- .build_Psi_q_ct(xval, xp, nodes, nodes_pow, object$degree_t, object$degree_g)
+Psi_q <- .build_Psi_q_ct(xval, xp, nodes, nodes_pow, object$degree_t, object$degree_g, object$degree_t_cross, object$degree_x_cross)
 V <- Psi_q %*% beta
 m <- max(V)
 v_shift <- V - m
 ev <- exp(pmax(v_shift, -object$clip))
 s <- sum(weights * ev)
 I_i <- xval * exp(m) * s
-psi_x <- .psi_basis_ct(xval, xp, object$degree_t, object$degree_g, TRUE)
+psi_x <- .psi_basis_ct(xval, xp, object$degree_t, object$degree_g, TRUE, object$degree_t_cross, object$degree_x_cross)
 Z_col[idx[b]] <- if (m_alpha > 0) sum(Phi_blk[b, ] * alpha) + I_i else I_i
 LJ_col[idx[b]] <- sum(beta * psi_x) - log(object$sigma[k])
 }

--- a/tests/testthat/test_ttm_cross_term_warmstart.R
+++ b/tests/testthat/test_ttm_cross_term_warmstart.R
@@ -1,0 +1,15 @@
+source("helper_config.R")
+source("../../models/ttm_separable.R")
+source("../../models/ttm_cross_term.R")
+
+set.seed(2024)
+prep <- prepare_data(100, config)
+
+fit_zero <- trainCrossTermMap(prep$S)
+fit_ws   <- trainCrossTermMap(prep$S, warmstart_from_separable = TRUE)
+
+(test_that("warm start converges and improves NLL", {
+  conv <- vapply(fit_ws$S$coeffs, function(c) c$convergence, numeric(1))
+  expect_true(all(conv == 0))
+  expect_true(fit_ws$NLL_val <= fit_zero$NLL_val + 1e-4)
+}))


### PR DESCRIPTION
## Zusammenfassung
- Erweitert die Cross-Term-Basis auf Polynome t^r * x_j^s mit steuerbaren Graden in t und x.
- Passt Training und Vorhersage an, inkl. neuer Parameter `degree_t_cross` und `degree_x_cross` sowie Speicherung in `S_map`.
- Aktualisiert Monotonie-Test und Algorithmus-Spezifikation entsprechend der erweiterten Basis.

## Testanweisungen
- `R -q -e 'testthat::test_dir("tests/testthat", reporter="summary")'`
- `R -q -f main.R`

------
https://chatgpt.com/codex/tasks/task_e_68a5902ca3fc8328a3f6e852beb3b831