### PR TITLE
Add two-moons dataset generator with validation and tests

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -67,6 +67,12 @@ where
 7. $f_7 = \texttt{format\_loglik\_table}$ – present final evaluation table.
 Optional EDA helper functions are defined in `04_evaluation.R`.
 
+Environment variables allow selecting alternative toy datasets. Setting `DATASET=halfmoon2d`
+triggers generation of a two-moons sample via `make_halfmoon_splits` with
+parameters `N_TRAIN`, `N_TEST` (capped at 250), `NOISE` and `SEED`. The created
+splits are stored as `results/splits_halfmoon2d_seedXXX.rds` and the RNG state is
+reset afterwards to keep subsequent model training comparable across datasets.
+
 ## 3. Module Specifications
 `gen_samples(G) : G \to X`
 - **Description:** sequentially draws $N=G.n$ samples from distributions specified in `G.config`.

--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -72,6 +72,9 @@ triggers generation of a two-moons sample via `make_halfmoon_splits` with
 parameters `N_TRAIN`, `N_TEST` (capped at 250), `NOISE` and `SEED`. The created
 splits are stored as `results/splits_halfmoon2d_seedXXX.rds` and the RNG state is
 reset afterwards to keep subsequent model training comparable across datasets.
+Evaluation `eval_halfmoon` fits TRUE, TRTF and the three TTM variants on these
+splits and records per-dimension and joint negative log-likelihoods (in nats)
+to `results/nll_halfmoon_seedXXX.csv`.
 
 ## 3. Module Specifications
 `gen_samples(G) : G \to X`

--- a/main.R
+++ b/main.R
@@ -2,6 +2,7 @@ source("00_globals.R")
 if (!exists("%||%")) "%||%" <- function(a, b) if (is.null(a)) b else a
 source("01_data_generation.R")
 source("02_split.R")
+source("scripts/halfmoon_data.R")
 source("models/true_model.R")
 source("models/trtf_model.R")
 source("models/ttm_marginal.R")
@@ -31,20 +32,40 @@ config <- list(
 #' 
 #' @export
 main <- function() {
-  set.seed(42)
-  prep <- prepare_data(n, config, seed = 42)
-  mods <- list(
-    true = fit_TRUE(prep$S, config),
-    true_joint = fit_TRUE_JOINT(prep$S, config),
-    trtf = fit_TRTF(prep$S, config, seed = 42),
-    ttm  = trainMarginalMap(prep$S),
-    ttm_sep = trainSeparableMap(prep$S),
-    ttm_cross = trainCrossTermMap(prep$S)
-  )
-  tab <- calc_loglik_tables(mods, config, prep$S$X_te)
-  print(tab)
-  results_table <<- tab
-  invisible(tab)
+  dataset <- Sys.getenv("DATASET", "config4d")
+  seed <- as.integer(Sys.getenv("SEED", 42))
+  set.seed(seed)
+
+  if (dataset == "halfmoon2d") {
+    ntr <- pmin(as.integer(Sys.getenv("N_TRAIN", 250)), 250)
+    nte <- pmin(as.integer(Sys.getenv("N_TEST", 250)), 250)
+    noise <- as.numeric(Sys.getenv("NOISE", 0.15))
+    S <- make_halfmoon_splits(ntr, nte, noise, seed)
+    S$meta$dataset <- dataset
+    dir.create("results", showWarnings = FALSE)
+    saveRDS(S, sprintf("results/splits_%s_seed%03d.rds", dataset, seed))
+    cat(sprintf("[DATASET %s] K=%d | n_tr=%d (val=%d) | n_te=%d | noise=%.3f | seed=%d\n",
+                dataset, ncol(S$X_tr), nrow(S$X_tr), nrow(S$X_val),
+                nrow(S$X_te), noise, seed))
+    set.seed(seed)
+    mods <- list()
+    eval_halfmoon(mods, S, NULL)
+    invisible(NULL)
+  } else {
+    prep <- prepare_data(n, config, seed = seed)
+    mods <- list(
+      true = fit_TRUE(prep$S, config),
+      true_joint = fit_TRUE_JOINT(prep$S, config),
+      trtf = fit_TRTF(prep$S, config, seed = seed),
+      ttm  = trainMarginalMap(prep$S),
+      ttm_sep = trainSeparableMap(prep$S),
+      ttm_cross = trainCrossTermMap(prep$S)
+    )
+    tab <- calc_loglik_tables(mods, config, prep$S$X_te)
+    print(tab)
+    results_table <<- tab
+    invisible(tab)
+  }
 }
 
 if (sys.nframe() == 0L) {

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -144,11 +144,6 @@ if (nrow(S$X_tr) + nrow(S$X_val) != n_train) stop("Training and validation sizes
 if (nrow(S$X_te) != n_test) stop("Test size inconsistent")
 S
 }
-eval_halfmoon <- function(mods, S, config = NULL) {
-cat(sprintf("[HALFMOON] n_tr=%d | n_val=%d | n_te=%d\n",
-nrow(S$X_tr), nrow(S$X_val), nrow(S$X_te)))
-invisible(NULL)
-}
 ### End scripts/halfmoon_data.R ###
 
 ### Begin models/true_model.R ###
@@ -1265,6 +1260,59 @@ nm[nm == "ttm_cross"] <- "Cross-term Map"
 names(tab) <- nm
 message("Ergebnis (NLL in nats; lower is better)")
 tab
+}
+eval_halfmoon <- function(mods, S, out_csv_path = NULL) {
+dir.create("results", showWarnings = FALSE)
+N <- nrow(S$X_te)
+K <- ncol(S$X_te)
+need <- c("true", "trtf", "ttm", "ttm_sep", "ttm_cross")
+config_moon <- list(list(distr = "norm"), list(distr = "norm"))
+if (missing(mods) || length(mods) == 0 || !all(need %in% names(mods))) {
+seed <- if (!is.null(S$meta$seed)) as.integer(S$meta$seed) else 42L
+set.seed(seed)
+mods <- list(
+true = fit_TRUE(S, config_moon),
+trtf = fit_TRTF(S, config_moon, seed = seed),
+ttm = trainMarginalMap(S)$S,
+ttm_sep = trainSeparableMap(S)$S,
+ttm_cross = trainCrossTermMap(S)$S
+)
+}
+rows <- list()
+for (m in need) {
+mod <- mods[[m]]
+if (m == "true") {
+cfg <- mod$config
+LD <- do.call(cbind, lapply(seq_len(K), function(k)
+.log_density_vec(S$X_te[, k], cfg[[k]]$distr, mod$theta[[k]])))
+} else {
+LD <- predict(mod, S$X_te, "logdensity_by_dim")
+}
+stopifnot(is.matrix(LD), all(dim(LD) == c(N, K)), all(is.finite(LD)))
+if (m == "true") {
+LDj <- rowSums(LD)
+} else {
+LDj_try <- try(predict(mod, S$X_te, "logdensity"), silent = TRUE)
+LDj <- if (inherits(LDj_try, "try-error")) rowSums(LD) else as.numeric(LDj_try)
+}
+stopifnot(length(LDj) == N, all(is.finite(LDj)),
+max(abs(rowSums(LD) - LDj)) < 1e-10)
+nllj <- -LDj
+per <- -colMeans(LD)
+se <- stats::sd(nllj) / sqrt(N)
+rows[[length(rows) + 1]] <- c(
+list(model = m, mean_joint_nll = mean(nllj), se_joint = se),
+setNames(as.list(per), paste0("per_dim_nll_", 1:K))
+)
+}
+df <- do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors = FALSE))
+path <- if (is.null(out_csv_path))
+sprintf("results/nll_halfmoon_seed%03d.csv", as.integer(S$meta$seed))
+else out_csv_path
+write.csv(df, path, row.names = FALSE)
+print(df)
+results_table <<- df
+df
 }
 ### End 04_evaluation.R ###
 

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -86,6 +86,71 @@ X[idx_te , , drop = FALSE]
 }
 ### End 02_split.R ###
 
+### Begin scripts/halfmoon_data.R ###
+generate_two_moons <- function(n, noise, seed) {
+stopifnot(is.numeric(n), n > 1, is.numeric(noise), is.numeric(seed))
+set.seed(seed)
+n1 <- floor(n / 2)
+n2 <- n - n1
+theta1 <- runif(n1, 0, pi)
+theta2 <- runif(n2, 0, pi)
+X1 <- cbind(cos(theta1), sin(theta1))
+X2 <- cbind(1 - cos(theta2), -sin(theta2) + 0.5)
+X <- rbind(X1, X2) + matrix(rnorm(2 * n, sd = noise), ncol = 2)
+idx <- sample.int(n)
+X <- X[idx, , drop = FALSE]
+colnames(X) <- c("x1", "x2")
+X
+}
+make_halfmoon_splits <- function(n_train, n_test, noise, seed, val_frac = 0.2) {
+Xtr <- generate_two_moons(n_train, noise, seed)
+Xte <- generate_two_moons(n_test, noise, seed + 1)
+n_val <- max(10L, round(val_frac * n_train))
+set.seed(seed + 2)
+idx <- sample.int(n_train, n_val)
+Xval <- Xtr[idx, , drop = FALSE]
+Xtr <- Xtr[-idx, , drop = FALSE]
+S <- list(
+X_tr = Xtr,
+X_val = Xval,
+X_te = Xte,
+K = 2L,
+meta = list(
+seed = seed,
+noise = noise,
+n_train = n_train,
+n_test = n_test,
+n_val = n_val,
+val_frac = val_frac
+)
+)
+check_halfmoon_splits(S)
+}
+check_halfmoon_splits <- function(S) {
+stopifnot(is.list(S), all(c("X_tr", "X_val", "X_te", "K", "meta") %in% names(S)))
+mats <- c("X_tr", "X_val", "X_te")
+for (m in mats) {
+X <- S[[m]]
+if (!is.matrix(X) || ncol(X) != 2) stop(m, " must be a numeric matrix with two columns")
+if (!is.numeric(X)) stop(m, " must be numeric")
+if (any(is.na(X)) || any(is.infinite(X))) stop(m, " contains NA or Inf")
+if (is.null(colnames(X)) || any(colnames(X) != c("x1", "x2"))) stop(m, " has wrong column names")
+}
+if (S$K != 2) stop("K must be 2")
+n_train <- S$meta$n_train
+n_test <- S$meta$n_test
+n_val <- S$meta$n_val
+if (nrow(S$X_tr) + nrow(S$X_val) != n_train) stop("Training and validation sizes inconsistent")
+if (nrow(S$X_te) != n_test) stop("Test size inconsistent")
+S
+}
+eval_halfmoon <- function(mods, S, config = NULL) {
+cat(sprintf("[HALFMOON] n_tr=%d | n_val=%d | n_te=%d\n",
+nrow(S$X_tr), nrow(S$X_val), nrow(S$X_te)))
+invisible(NULL)
+}
+### End scripts/halfmoon_data.R ###
+
 ### Begin models/true_model.R ###
 neg_loglik_uni <- function(par, x, distr) {
 if (distr == "norm") {
@@ -1208,6 +1273,7 @@ source("00_globals.R")
 if (!exists("%||%")) "%||%" <- function(a, b) if (is.null(a)) b else a
 source("01_data_generation.R")
 source("02_split.R")
+source("scripts/halfmoon_data.R")
 source("models/true_model.R")
 source("models/trtf_model.R")
 source("models/ttm_marginal.R")
@@ -1228,12 +1294,30 @@ parm = function(d) list(shape = softplus(d$X3),
 scale = softplus(d$X2)))
 )
 main <- function() {
-set.seed(42)
-prep <- prepare_data(n, config, seed = 42)
+dataset <- Sys.getenv("DATASET", "config4d")
+seed <- as.integer(Sys.getenv("SEED", 42))
+set.seed(seed)
+if (dataset == "halfmoon2d") {
+ntr <- pmin(as.integer(Sys.getenv("N_TRAIN", 250)), 250)
+nte <- pmin(as.integer(Sys.getenv("N_TEST", 250)), 250)
+noise <- as.numeric(Sys.getenv("NOISE", 0.15))
+S <- make_halfmoon_splits(ntr, nte, noise, seed)
+S$meta$dataset <- dataset
+dir.create("results", showWarnings = FALSE)
+saveRDS(S, sprintf("results/splits_%s_seed%03d.rds", dataset, seed))
+cat(sprintf("[DATASET %s] K=%d | n_tr=%d (val=%d) | n_te=%d | noise=%.3f | seed=%d\n",
+dataset, ncol(S$X_tr), nrow(S$X_tr), nrow(S$X_val),
+nrow(S$X_te), noise, seed))
+set.seed(seed)
+mods <- list()
+eval_halfmoon(mods, S, NULL)
+invisible(NULL)
+} else {
+prep <- prepare_data(n, config, seed = seed)
 mods <- list(
 true = fit_TRUE(prep$S, config),
 true_joint = fit_TRUE_JOINT(prep$S, config),
-trtf = fit_TRTF(prep$S, config, seed = 42),
+trtf = fit_TRTF(prep$S, config, seed = seed),
 ttm  = trainMarginalMap(prep$S),
 ttm_sep = trainSeparableMap(prep$S),
 ttm_cross = trainCrossTermMap(prep$S)
@@ -1242,6 +1326,7 @@ tab <- calc_loglik_tables(mods, config, prep$S$X_te)
 print(tab)
 results_table <<- tab
 invisible(tab)
+}
 }
 if (sys.nframe() == 0L) {
 main()

--- a/scripts/halfmoon_data.R
+++ b/scripts/halfmoon_data.R
@@ -1,0 +1,89 @@
+#' Two-moons data generator and split utilities
+#'
+#' This script provides functions to create the classic two-moons dataset
+#' and split it into training, validation and test sets.
+
+#' Generate two-moons points
+#'
+#' @param n Number of samples to generate
+#' @param noise Standard deviation of Gaussian noise added to the points
+#' @param seed Random seed for reproducibility
+#' @return Numeric matrix with columns x1 and x2
+#' @export
+#' @examples
+#' X <- generate_two_moons(100, 0.1, 1)
+#' plot(X)
+generate_two_moons <- function(n, noise, seed) {
+  stopifnot(is.numeric(n), n > 1, is.numeric(noise), is.numeric(seed))
+  set.seed(seed)
+  n1 <- floor(n / 2)
+  n2 <- n - n1
+  theta1 <- runif(n1, 0, pi)
+  theta2 <- runif(n2, 0, pi)
+  X1 <- cbind(cos(theta1), sin(theta1))
+  X2 <- cbind(1 - cos(theta2), -sin(theta2) + 0.5)
+  X <- rbind(X1, X2) + matrix(rnorm(2 * n, sd = noise), ncol = 2)
+  idx <- sample.int(n)
+  X <- X[idx, , drop = FALSE]
+  colnames(X) <- c("x1", "x2")
+  X
+}
+
+#' Create train/validation/test splits for two-moons data
+#'
+#' @param n_train Number of training samples before validation split
+#' @param n_test Number of test samples
+#' @param noise Noise level passed to `generate_two_moons`
+#' @param seed Random seed
+#' @param val_frac Fraction of training data used for validation
+#' @return List with train, validation and test matrices and metadata
+#' @export
+make_halfmoon_splits <- function(n_train, n_test, noise, seed, val_frac = 0.2) {
+  Xtr <- generate_two_moons(n_train, noise, seed)
+  Xte <- generate_two_moons(n_test, noise, seed + 1)
+  n_val <- max(10L, round(val_frac * n_train))
+  set.seed(seed + 2)
+  idx <- sample.int(n_train, n_val)
+  Xval <- Xtr[idx, , drop = FALSE]
+  Xtr <- Xtr[-idx, , drop = FALSE]
+  S <- list(
+    X_tr = Xtr,
+    X_val = Xval,
+    X_te = Xte,
+    K = 2L,
+    meta = list(
+      seed = seed,
+      noise = noise,
+      n_train = n_train,
+      n_test = n_test,
+      n_val = n_val,
+      val_frac = val_frac
+    )
+  )
+  check_halfmoon_splits(S)
+}
+
+#' Validate two-moons data splits
+#'
+#' @param S Split list as produced by `make_halfmoon_splits`
+#' @return The input list if all checks pass
+#' @export
+check_halfmoon_splits <- function(S) {
+  stopifnot(is.list(S), all(c("X_tr", "X_val", "X_te", "K", "meta") %in% names(S)))
+  mats <- c("X_tr", "X_val", "X_te")
+  for (m in mats) {
+    X <- S[[m]]
+    if (!is.matrix(X) || ncol(X) != 2) stop(m, " must be a numeric matrix with two columns")
+    if (!is.numeric(X)) stop(m, " must be numeric")
+    if (any(is.na(X)) || any(is.infinite(X))) stop(m, " contains NA or Inf")
+    if (is.null(colnames(X)) || any(colnames(X) != c("x1", "x2"))) stop(m, " has wrong column names")
+  }
+  if (S$K != 2) stop("K must be 2")
+  n_train <- S$meta$n_train
+  n_test <- S$meta$n_test
+  n_val <- S$meta$n_val
+  if (nrow(S$X_tr) + nrow(S$X_val) != n_train) stop("Training and validation sizes inconsistent")
+  if (nrow(S$X_te) != n_test) stop("Test size inconsistent")
+  S
+}
+

--- a/scripts/halfmoon_data.R
+++ b/scripts/halfmoon_data.R
@@ -86,17 +86,3 @@ check_halfmoon_splits <- function(S) {
   if (nrow(S$X_te) != n_test) stop("Test size inconsistent")
   S
 }
-
-#' Placeholder evaluation for half-moon dataset
-#'
-#' @param mods List of fitted models (unused)
-#' @param S Split structure from `make_halfmoon_splits`
-#' @param config Optional configuration (unused)
-#' @return Invisible NULL after printing a short summary
-#' @export
-eval_halfmoon <- function(mods, S, config = NULL) {
-  cat(sprintf("[HALFMOON] n_tr=%d | n_val=%d | n_te=%d\n",
-              nrow(S$X_tr), nrow(S$X_val), nrow(S$X_te)))
-  invisible(NULL)
-}
-

--- a/scripts/halfmoon_data.R
+++ b/scripts/halfmoon_data.R
@@ -87,3 +87,16 @@ check_halfmoon_splits <- function(S) {
   S
 }
 
+#' Placeholder evaluation for half-moon dataset
+#'
+#' @param mods List of fitted models (unused)
+#' @param S Split structure from `make_halfmoon_splits`
+#' @param config Optional configuration (unused)
+#' @return Invisible NULL after printing a short summary
+#' @export
+eval_halfmoon <- function(mods, S, config = NULL) {
+  cat(sprintf("[HALFMOON] n_tr=%d | n_val=%d | n_te=%d\n",
+              nrow(S$X_tr), nrow(S$X_val), nrow(S$X_te)))
+  invisible(NULL)
+}
+

--- a/tests/testthat/test_halfmoon_data.R
+++ b/tests/testthat/test_halfmoon_data.R
@@ -1,0 +1,38 @@
+source("../../scripts/halfmoon_data.R")
+
+context("two-moons dataset")
+
+test_that("generate_two_moons reproducibility and shape", {
+  n <- 40L
+  noise <- 0.05
+  seed <- 7
+  X1 <- generate_two_moons(n, noise, seed)
+  X2 <- generate_two_moons(n, noise, seed)
+  expect_true(is.matrix(X1))
+  expect_identical(dim(X1), c(n, 2L))
+  expect_identical(colnames(X1), c("x1", "x2"))
+  expect_identical(X1, X2)
+  expect_false(any(!is.finite(X1)))
+})
+
+test_that("make_halfmoon_splits produces consistent splits", {
+  n_train <- 60L
+  n_test <- 30L
+  noise <- 0.1
+  seed <- 13
+  S1 <- make_halfmoon_splits(n_train, n_test, noise, seed)
+  S2 <- make_halfmoon_splits(n_train, n_test, noise, seed)
+  expect_identical(S1, S2)
+  n_val <- as.integer(max(10, round(0.2 * n_train)))
+  expect_identical(dim(S1$X_tr), c(as.integer(n_train - n_val), 2L))
+  expect_identical(dim(S1$X_val), c(n_val, 2L))
+  expect_identical(dim(S1$X_te), c(n_test, 2L))
+  expect_identical(colnames(S1$X_tr), c("x1", "x2"))
+  expect_identical(colnames(S1$X_val), c("x1", "x2"))
+  expect_identical(colnames(S1$X_te), c("x1", "x2"))
+  expect_equal(S1$K, 2L)
+  expect_false(any(!is.finite(S1$X_tr)))
+  expect_false(any(!is.finite(S1$X_val)))
+  expect_false(any(!is.finite(S1$X_te)))
+  expect_identical(check_halfmoon_splits(S1), S1)
+})

--- a/tests/testthat/test_main_halfmoon.R
+++ b/tests/testthat/test_main_halfmoon.R
@@ -1,0 +1,10 @@
+source(file.path(testthat::test_path("..", ".."), "main.R"), chdir = TRUE)
+
+test_that("main handles halfmoon2d dataset", {
+  withr::local_envvar(c(DATASET="halfmoon2d", N_TRAIN="20", N_TEST="20", NOISE="0.1", SEED="7"))
+  f <- "results/splits_halfmoon2d_seed007.rds"
+  unlink(f)
+  on.exit(unlink(f), add = TRUE)
+  expect_output(main(), "\\[DATASET halfmoon2d\\]")
+  expect_true(file.exists(f))
+})

--- a/tests/testthat/test_main_halfmoon.R
+++ b/tests/testthat/test_main_halfmoon.R
@@ -2,9 +2,14 @@ source(file.path(testthat::test_path("..", ".."), "main.R"), chdir = TRUE)
 
 test_that("main handles halfmoon2d dataset", {
   withr::local_envvar(c(DATASET="halfmoon2d", N_TRAIN="20", N_TEST="20", NOISE="0.1", SEED="7"))
-  f <- "results/splits_halfmoon2d_seed007.rds"
-  unlink(f)
-  on.exit(unlink(f), add = TRUE)
+  f_split <- "results/splits_halfmoon2d_seed007.rds"
+  f_csv <- "results/nll_halfmoon_seed007.csv"
+  unlink(c(f_split, f_csv))
+  on.exit(unlink(c(f_split, f_csv)), add = TRUE)
   expect_output(main(), "\\[DATASET halfmoon2d\\]")
-  expect_true(file.exists(f))
+  expect_true(file.exists(f_split))
+  expect_true(file.exists(f_csv))
+  df <- read.csv(f_csv, stringsAsFactors = FALSE)
+  expect_equal(df$model, c("true", "trtf", "ttm", "ttm_sep", "ttm_cross"))
+  expect_true(all(is.finite(as.matrix(df[,-1]))))
 })


### PR DESCRIPTION
## Summary
- implement `generate_two_moons` and splitting/validation helpers
- add tests covering shapes, reproducibility, and sanity checks

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_68a6f37db210832886dbd8cba60c203c