### PR TITLE
Spaltenpermutation und n-Ausgabe vor NLL-Tabelle

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -56,6 +56,7 @@ $$\operatorname{mainPipeline} := f_7 \circ f_6 \circ \cdots \circ f_1,$$
 where
 1. $f_1 = \texttt{gen\_samples}$ – generate $X$ from configuration.
 2. $f_2 = \texttt{split\_data}$ – obtain $(X_{\text{tr}}, X_{\text{val}}, X_{\text{te}})$.
+   $f_{2a} =$ optional column permutation $S \mapsto S_{perm}$ with corresponding config reordering.
 3. $f_3 = \texttt{fit\_TRUE}$ – fit independent parametric marginals.
    f_3b1 = fit_TTM_marginal
    f_3b2 = fit_TTM_separable

--- a/main.R
+++ b/main.R
@@ -11,6 +11,7 @@ source("models/true_joint_model.R")
 source("04_evaluation.R")
 source("replicate_code.R")
 
+perm <- c(1, 2, 3, 4)
 n <- 50
 config <- list(
   list(distr = "norm", parm = NULL),
@@ -33,15 +34,23 @@ config <- list(
 main <- function() {
   set.seed(42)
   prep <- prepare_data(n, config, seed = 42)
-  mods <- list(
-    true = fit_TRUE(prep$S, config),
-    true_joint = fit_TRUE_JOINT(prep$S, config),
-    trtf = fit_TRTF(prep$S, config, seed = 42),
-    ttm  = trainMarginalMap(prep$S),
-    ttm_sep = trainSeparableMap(prep$S),
-    ttm_cross = trainCrossTermMap(prep$S)
+  S0 <- prep$S
+  S <- list(
+    X_tr  = S0$X_tr[, perm, drop = FALSE],
+    X_val = S0$X_val[, perm, drop = FALSE],
+    X_te  = S0$X_te[, perm, drop = FALSE]
   )
-  tab <- calc_loglik_tables(mods, config, prep$S$X_te)
+  cfg <- config[perm]
+  cat(sprintf("n=%d\n", n))
+  mods <- list(
+    true = fit_TRUE(S, cfg),
+    true_joint = fit_TRUE_JOINT(S, cfg),
+    trtf = fit_TRTF(S, cfg, seed = 42),
+    ttm  = trainMarginalMap(S),
+    ttm_sep = trainSeparableMap(S),
+    ttm_cross = trainCrossTermMap(S)
+  )
+  tab <- calc_loglik_tables(mods, cfg, S$X_te)
   print(tab)
   results_table <<- tab
   invisible(tab)

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -1216,6 +1216,7 @@ source("models/ttm_cross_term.R")
 source("models/true_joint_model.R")
 source("04_evaluation.R")
 source("replicate_code.R")
+perm <- c(1, 2, 3, 4)
 n <- 50
 config <- list(
 list(distr = "norm", parm = NULL),
@@ -1230,15 +1231,23 @@ scale = softplus(d$X2)))
 main <- function() {
 set.seed(42)
 prep <- prepare_data(n, config, seed = 42)
-mods <- list(
-true = fit_TRUE(prep$S, config),
-true_joint = fit_TRUE_JOINT(prep$S, config),
-trtf = fit_TRTF(prep$S, config, seed = 42),
-ttm  = trainMarginalMap(prep$S),
-ttm_sep = trainSeparableMap(prep$S),
-ttm_cross = trainCrossTermMap(prep$S)
+S0 <- prep$S
+S <- list(
+X_tr  = S0$X_tr[, perm, drop = FALSE],
+X_val = S0$X_val[, perm, drop = FALSE],
+X_te  = S0$X_te[, perm, drop = FALSE]
 )
-tab <- calc_loglik_tables(mods, config, prep$S$X_te)
+cfg <- config[perm]
+cat(sprintf("n=%d\n", n))
+mods <- list(
+true = fit_TRUE(S, cfg),
+true_joint = fit_TRUE_JOINT(S, cfg),
+trtf = fit_TRTF(S, cfg, seed = 42),
+ttm  = trainMarginalMap(S),
+ttm_sep = trainSeparableMap(S),
+ttm_cross = trainCrossTermMap(S)
+)
+tab <- calc_loglik_tables(mods, cfg, S$X_te)
 print(tab)
 results_table <<- tab
 invisible(tab)


### PR DESCRIPTION
## Zusammenfassung
- Permutation `perm` eingeführt und auf Daten sowie Konfiguration angewendet
- Ausgabe von `n=` vor der NLL-Tabelle ergänzt
- Pipeline-Dokumentation um optionalen Permutationsschritt erweitert

## Test
- `Rscript main.R`
- `Rscript -e 'testthat::test_dir("tests/testthat", reporter="summary")'`

------
https://chatgpt.com/codex/tasks/task_e_68a6f3fe5f3c83289f14ad168a0a0370