### PR TITLE
Refaktoriert: Halbmond über ENV-Parameter

### DIFF
--- a/main.R
+++ b/main.R
@@ -34,25 +34,23 @@ config <- list(
 #' @export
 main <- function() {
   dataset <- Sys.getenv("DATASET", "config4d")
-  seed <- as.integer(Sys.getenv("SEED", 42))
-  set.seed(seed)
-
   if (dataset == "halfmoon2d") {
-    ntr <- pmin(as.integer(Sys.getenv("N_TRAIN", 250)), 250)
-    nte <- pmin(as.integer(Sys.getenv("N_TEST", 250)), 250)
-    noise <- as.numeric(Sys.getenv("NOISE", 0.15))
-    S <- make_halfmoon_splits(ntr, nte, noise, seed)
+    seed <- as.integer(Sys.getenv("SEED"))
+    set.seed(seed)
+    ntr <- as.integer(Sys.getenv("N_TRAIN"))
+    nte <- as.integer(Sys.getenv("N_TEST"))
+    noise <- as.numeric(Sys.getenv("NOISE"))
+    S <- make_halfmoon_splits(ntr, nte, noise, seed, val_frac = 0.2)
     S$meta$dataset <- dataset
     dir.create("results", showWarnings = FALSE)
     saveRDS(S, sprintf("results/splits_%s_seed%03d.rds", dataset, seed))
-    cat(sprintf("[DATASET %s] K=%d | n_tr=%d (val=%d) | n_te=%d | noise=%.3f | seed=%d\n",
-                dataset, ncol(S$X_tr), nrow(S$X_tr), nrow(S$X_val),
-                nrow(S$X_te), noise, seed))
     df <- eval_halfmoon(S = S)
-    assign("results_table", df, envir = .GlobalEnv)
+    results_table <<- df
     return(df)
   }
 
+  seed <- as.integer(Sys.getenv("SEED", 42))
+  set.seed(seed)
   prep <- prepare_data(n, config, seed = seed)
   S0 <- prep$S
   S <- list(

--- a/main_moon.R
+++ b/main_moon.R
@@ -1,23 +1,18 @@
-seed  <- 7L
-ntr   <- 80L
-nte   <- 80L
-noise <- 0.15
+SEED <- 7L; N <- 50L; NOISE <- 0.15
 Sys.setenv(
   DATASET = "halfmoon2d",
-  N_TRAIN = as.character(ntr),
-  N_TEST  = as.character(nte),
-  NOISE   = as.character(noise),
-  SEED    = as.character(seed)
+  SEED = as.character(SEED),
+  N_TRAIN = as.character(N),
+  N_TEST = as.character(N),
+  NOISE = as.character(NOISE)
 )
-source("main.R")
-tab <- main()
-csv <- sprintf("results/nll_halfmoon_seed%03d.csv", seed)
+source("main.R"); tab <- main()
+csv <- sprintf("results/nll_halfmoon_seed%03d.csv", SEED)
 stopifnot(file.exists(csv))
-S <- readRDS(sprintf("results/splits_halfmoon2d_seed%03d.rds", seed))
-source("scripts/halfmoon_plot.R")
-mods <- fit_halfmoon_models(S, seed = seed)
+S <- readRDS(sprintf("results/splits_halfmoon2d_seed%03d.rds", SEED))
+source("scripts/halfmoon_plot.R"); mods <- fit_halfmoon_models(S, seed = SEED)
 plot_halfmoon_models(mods, S, save_png = TRUE, show_plot = FALSE)
-png_file <- sprintf("results/halfmoon_panels_seed%03d.png", seed)
+png_file <- sprintf("results/halfmoon_panels_seed%03d.png", SEED)
 stopifnot(file.exists(png_file))
 stopifnot(identical(tab, results_table))
 print(tab)

--- a/replicated_code.txt
+++ b/replicated_code.txt
@@ -1357,23 +1357,22 @@ scale = softplus(d$X2)))
 )
 main <- function() {
 dataset <- Sys.getenv("DATASET", "config4d")
-seed <- as.integer(Sys.getenv("SEED", 42))
-set.seed(seed)
 if (dataset == "halfmoon2d") {
-ntr <- pmin(as.integer(Sys.getenv("N_TRAIN", 250)), 250)
-nte <- pmin(as.integer(Sys.getenv("N_TEST", 250)), 250)
-noise <- as.numeric(Sys.getenv("NOISE", 0.15))
-S <- make_halfmoon_splits(ntr, nte, noise, seed)
+seed <- as.integer(Sys.getenv("SEED"))
+set.seed(seed)
+ntr <- as.integer(Sys.getenv("N_TRAIN"))
+nte <- as.integer(Sys.getenv("N_TEST"))
+noise <- as.numeric(Sys.getenv("NOISE"))
+S <- make_halfmoon_splits(ntr, nte, noise, seed, val_frac = 0.2)
 S$meta$dataset <- dataset
 dir.create("results", showWarnings = FALSE)
 saveRDS(S, sprintf("results/splits_%s_seed%03d.rds", dataset, seed))
-cat(sprintf("[DATASET %s] K=%d | n_tr=%d (val=%d) | n_te=%d | noise=%.3f | seed=%d\n",
-dataset, ncol(S$X_tr), nrow(S$X_tr), nrow(S$X_val),
-nrow(S$X_te), noise, seed))
 df <- eval_halfmoon(S = S)
-assign("results_table", df, envir = .GlobalEnv)
+results_table <<- df
 return(df)
 }
+seed <- as.integer(Sys.getenv("SEED", 42))
+set.seed(seed)
 prep <- prepare_data(n, config, seed = seed)
 S0 <- prep$S
 S <- list(
@@ -1433,11 +1432,11 @@ replicate_code_scripts("main.R", "replicated_code.txt", env = globalenv())
 
 ### Final results table ###
       model mean_joint_nll   se_joint per_dim_nll_1 per_dim_nll_2
-1      true       2.015435 0.03952443      1.315586     0.6998488
-2      trtf       1.773099 0.04477884      1.261374     0.5117247
-3       ttm       2.024118 0.03678561      1.313244     0.7108738
-4   ttm_sep       1.978473 0.04581926      1.315586     0.6628871
-5 ttm_cross       1.923089 0.04957322      1.307709     0.6153796
+1      true       2.104691 0.10149634      1.262607     0.8420842
+2      trtf       2.122549 0.11744378      1.293472     0.8290772
+3       ttm       2.113508 0.07909828      1.297692     0.8158159
+4   ttm_sep       2.108669 0.10671346      1.262609     0.8460600
+5 ttm_cross       2.130100 0.14588430      1.243081     0.8870187
 
 Permutation order 1,2,3,4
 


### PR DESCRIPTION
## Zusammenfassung
- `main_moon.R` auf kompakten Parameterblock mit N und NOISE reduziert
- `main.R` erhält Early-Return für `halfmoon2d` über Umgebungsvariablen
- `replicated_code.txt` aktualisiert

## Test
- `Rscript -e 'S<-readRDS("results/splits_halfmoon2d_seed007.rds"); cat(nrow(S$X_tr)+nrow(S$X_val),"\n",nrow(S$X_te),"\n")'`
- `Rscript -e 'source("main.R"); S<-readRDS("results/splits_halfmoon2d_seed007.rds"); source("scripts/halfmoon_plot.R"); mods<-fit_halfmoon_models(S, seed=7); LD<-predict(mods$ttm, S$X_te, "logdensity_by_dim"); cat(dim(LD),"\n"); LDj<-predict(mods$ttm, S$X_te, "logdensity"); cat(max(abs(rowSums(LD)-LDj)),"\n")'`
- `find results -maxdepth 1 -name '*png'` *(keine PNG-Datei erzeugt)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a4400f88328942d9ce79cd40f0d