### PR TITLE
Adaptive grid evaluation with caching for half-moon panels

### DIFF
--- a/ALGORITHM_SPEC.md
+++ b/ALGORITHM_SPEC.md
@@ -195,7 +195,7 @@ Most expressive; computationally heavier due to the 1‑D integral and stabiliza
 
 * Build a single grid $[x_{\min},x_{\max}]\times[y_{\min},y_{\max}]$ from all splits with \~5 % padding.
 * Evaluate **joint** log‑density on the same grid for all models.
-* Use **global contour levels** (e.g. pooled quantiles $\{0.90,0.70,0.50\}$) to ensure comparability.
+* Use **iso-mass contour levels** (e.g. pooled quantiles $\{0.90,0.70,0.50\}$) to ensure comparability.
 * Draw data points last so they are visible above contours; use identical axes in all panels.
 * Save `results/halfmoon_panels_seedXXX.png`; optionally show on screen.
 
@@ -381,13 +381,15 @@ PREDICT:
 * Separable: degree $g$ ∈ {1,2,3}; $\lambda\in\{10^{-6},10^{-5},10^{-4},10^{-3},10^{-2}\}$; $\varepsilon=10^{-6}$.
 * Cross‑term: quadrature nodes $Q\in\{8,16,32\}$; small L2 on β.
 * TRTF: `ntree ≈ n_tr`, `minsplit∈[20,100]`, `maxdepth∈[2,5]`, `minbucket∈[5,30]`.
-* Panels: `grid_n ≥ 200`; `levels_policy = "global"`.
+* Half‑Moon panels: `grid_side = clamp(⌊√(100·N_tr)⌋,80,200)` unless overridden;
+  contour levels from iso‑mass thresholds {0.5,0.7,0.9};
+  grid evaluations cached under `results/cache/moon_<digest>.rds`.
 
 ---
 
 ## Short thesis paragraph (ready to paste)
 
-We train lower‑triangular, strictly monotone target‑to‑reference maps $\mathbf{S}$ in the forward‑KL formulation (paper Eq. 36–39). We instantiate three parameterizations—marginal (Eq. 20), separable (Eq. 21), and cross‑term (Eq. 22)—and evaluate them against conditional transformation forests (TRTF). All computations, both training and test, run in **log‑space** with explicit Gaussian constants and train‑only standardization offsets. The per‑sample joint log‑density equals the sum over dimensions of $-\tfrac12 z_k^2 - \tfrac12\log(2\pi) + \log\partial_k S_k$. We report mean NLL (nats) with ±2·SE per dimension and in a SUM row, and we visualize Half‑Moon density shapes on a shared grid with global contour levels.
+We train lower‑triangular, strictly monotone target‑to‑reference maps $\mathbf{S}$ in the forward‑KL formulation (paper Eq. 36–39). We instantiate three parameterizations—marginal (Eq. 20), separable (Eq. 21), and cross‑term (Eq. 22)—and evaluate them against conditional transformation forests (TRTF). All computations, both training and test, run in **log‑space** with explicit Gaussian constants and train‑only standardization offsets. The per‑sample joint log‑density equals the sum over dimensions of $-\tfrac12 z_k^2 - \tfrac12\log(2\pi) + \log\partial_k S_k$. We report mean NLL (nats) with ±2·SE per dimension and in a SUM row, and we visualize Half‑Moon density shapes on a shared grid with iso-mass contour levels.
 
 ---
 

--- a/main_moon.R
+++ b/main_moon.R
@@ -1,3 +1,10 @@
+args <- commandArgs(trailingOnly = TRUE)
+grid_side_arg <- NA_integer_
+no_cache <- FALSE
+for (a in args) {
+  if (grepl("^--grid_side=", a)) grid_side_arg <- as.integer(sub("^--grid_side=", "", a))
+  if (a == "--no_cache") no_cache <- TRUE
+}
 SEED <- 7L; N <- 100L; NOISE <- 0.15
 Sys.setenv(
   DATASET = "halfmoon2d",
@@ -10,9 +17,13 @@ source("main.R"); tab <- main()
 csv <- sprintf("results/nll_halfmoon_seed%03d.csv", SEED)
 stopifnot(file.exists(csv))
 S <- readRDS(sprintf("results/splits_halfmoon2d_seed%03d.rds", SEED))
+clamp <- function(x, lo, hi) pmax(lo, pmin(hi, x))
+N_tr <- nrow(S$X_tr)
+grid_side <- if (!is.na(grid_side_arg)) grid_side_arg else clamp(floor(sqrt(100 * N_tr)), 80L, 200L)
 source("scripts/halfmoon_plot.R"); mods <- fit_halfmoon_models(S, seed = SEED)
-plot_halfmoon_models_gg(mods, S, save_png = TRUE, show_plot = FALSE)
-png_file <- sprintf("results/halfmoon_panels_seed%03d.png", SEED)
+res <- plot_halfmoon_models(mods, S, grid_side = grid_side, save_png = TRUE,
+                            show_plot = FALSE, no_cache = no_cache)
+png_file <- res$png
 stopifnot(file.exists(png_file))
 stopifnot(identical(tab, results_table))
 print(tab)

--- a/scripts/halfmoon_plot.R
+++ b/scripts/halfmoon_plot.R
@@ -44,45 +44,85 @@ clip01 <- function(x) {
   pmin(pmax(x, q[1]), q[2])
 }
 
-.draw_panels <- function(mods, S, grid_n, levels_policy = c("global_quantiles", "per_model")) {
-  levels_policy <- match.arg(levels_policy)
-  lim <- compute_limits(S, pad = 0.05)
-  xseq <- seq(lim$xlim[1], lim$xlim[2], length.out = grid_n)
-  yseq <- seq(lim$ylim[1], lim$ylim[2], length.out = grid_n)
+lse <- function(x) {
+  m <- max(x)
+  m + log(sum(exp(x - m)))
+}
+
+iso_mass_levels <- function(joint, xlim, ylim, grid_side, masses) {
+  area <- (diff(xlim) / grid_side) * (diff(ylim) / grid_side)
+  logp <- joint + log(area)
+  p <- exp(logp - lse(logp))
+  ord <- order(joint, decreasing = TRUE)
+  cs <- cumsum(p[ord])
+  sapply(masses, function(m) joint[ord][which(cs >= m)[1]])
+}
+
+eval_density_grid <- function(model, G, xlim, ylim, grid_side, seed,
+                              type = "logdensity_by_dim", chunk = 2048,
+                              cores = min(10L, parallel::detectCores() - 2L),
+                              no_cache = FALSE) {
+  stopifnot(is.matrix(G))
+  model_sig <- digest::digest(utils::capture.output(str(model)))
+  cache_key <- digest::digest(list(model_sig, xlim, ylim, grid_side, seed))
+  dir.create("results/cache", showWarnings = FALSE, recursive = TRUE)
+  cache_path <- file.path("results/cache", sprintf("moon_%s.rds", cache_key))
+  if (file.exists(cache_path) && !no_cache) {
+    message("Lade Cache: ", cache_path)
+    return(readRDS(cache_path))
+  }
+  N <- nrow(G)
+  idx <- split(seq_len(N), ceiling(seq_len(N) / chunk))
+  if (getOption("mde.parallel_active", FALSE)) cores <- 1L
+  options(mde.parallel_active = TRUE)
+  on.exit(options(mde.parallel_active = FALSE), add = TRUE)
+  chunk_fun <- function(ii) {
+    Xc <- G[ii, , drop = FALSE]
+    pr <- try(predict(model, Xc, type = type, cores = 1L), silent = TRUE)
+    if (inherits(pr, "try-error")) pr <- predict(model, Xc, type = type)
+    stopifnot(is.matrix(pr), nrow(pr) == nrow(Xc))
+    pr
+  }
+  LD_parts <- parallel::mclapply(idx, chunk_fun, mc.cores = cores)
+  LD <- do.call(rbind, LD_parts)
+  stopifnot(nrow(LD) == N)
+  joint <- rowSums(LD)
+  if (any(!is.finite(LD))) stop("NA/Inf in log-dichte")
+  joint_ref <- try(predict(model, G, type = "logdensity", cores = 1L), silent = TRUE)
+  if (inherits(joint_ref, "try-error")) joint_ref <- predict(model, G, "logdensity")
+  stopifnot(length(joint_ref) == N, max(abs(joint - joint_ref)) <= 1e-10)
+  obj <- list(LD = LD, joint = joint,
+              meta = list(cache_key = cache_key, cache_path = cache_path,
+                          chunk = chunk, cores = cores, grid_side = grid_side,
+                          xlim = xlim, ylim = ylim, seed = seed,
+                          model_signature = model_sig))
+  saveRDS(obj, cache_path)
+  message("Speichere Cache: ", cache_path)
+  obj
+}
+
+plot_halfmoon_models <- function(mods, S, grid_side,
+                                 chunk = 2048,
+                                 cores = min(10L, parallel::detectCores() - 2L),
+                                 save_png = TRUE, show_plot = TRUE,
+                                 no_cache = FALSE) {
+  seed <- if (!is.null(S$meta$seed)) S$meta$seed else 0L
+  Xtr <- S$X_tr
+  mu <- colMeans(Xtr)
+  sdv <- apply(Xtr, 2, sd)
+  xlim <- mu[1] + c(-3, 3) * sdv[1]
+  ylim <- mu[2] + c(-3, 3) * sdv[2]
+  xseq <- seq(xlim[1], xlim[2], length.out = grid_side)
+  yseq <- seq(ylim[1], ylim[2], length.out = grid_side)
   G <- as.matrix(expand.grid(xseq, yseq))
-  get_LDj_true <- function(mod_true) {
-    cbind(
-      .log_density_vec(G[, 1], "norm", mod_true$theta[[1]]),
-      .log_density_vec(G[, 2], "norm", mod_true$theta[[2]])
-    ) |> rowSums()
-  }
-  get_LDj <- function(name) {
-    if (name == "true") {
-      get_LDj_true(mods$true)
-    } else {
-      as.numeric(predict(mods[[name]], G, "logdensity"))
-    }
-  }
-  panels <- c("true", "trtf", "ttm", "ttm_sep", "ttm_cross")
-  LD_list <- setNames(lapply(panels, get_LDj), panels)
-  all_finite <- all(sapply(LD_list, function(z) all(is.finite(z))))
-  probs <- c(0.9, 0.7, 0.5)
-  if (levels_policy == "global_quantiles") {
-    all_vals <- unlist(lapply(LD_list, function(z) clip01(z[is.finite(z)])))
-    lev <- stats::quantile(all_vals, probs)
-    message("Contour levels (global): ", paste(sprintf("%.3f", lev), collapse = ", "))
-    lev_list <- rep(list(lev), length(panels))
-    names(lev_list) <- panels
-    lev_ret <- lev
-  } else {
-    lev_list <- lapply(LD_list, function(z) {
-      stats::quantile(clip01(z[is.finite(z)]), probs)
-    })
-    message("Contour levels (per_model): ",
-            paste(names(lev_list),
-                  sapply(lev_list, function(v) paste(sprintf("%.3f", v), collapse = ", ")), collapse = " | "))
-    lev_ret <- lev_list
-  }
+  panels <- c("true", "trtf", "ttm_cross")
+  evals <- setNames(lapply(panels, function(nm) {
+    eval_density_grid(mods[[nm]], G, xlim, ylim, grid_side, seed,
+                      chunk = chunk, cores = cores, no_cache = no_cache)
+  }), panels)
+  LD_list <- lapply(evals, `[[`, "joint")
+  lev_list <- lapply(LD_list, iso_mass_levels, xlim = xlim, ylim = ylim,
+                     grid_side = grid_side, masses = c(0.5, 0.7, 0.9))
   n_all <- nrow(S$X_tr) + nrow(S$X_val) + nrow(S$X_te)
   style <- list(
     cex = min(1.2, sqrt(800 / n_all)),
@@ -90,122 +130,46 @@ clip01 <- function(x) {
              val = rgb(1, 0.6, 0, 0.5),
              test = rgb(1, 0, 0, 0.7))
   )
-  op <- par(mfrow = c(2, 3), mar = c(3, 3, 2, 1))
-  plot(NA, xlim = lim$xlim, ylim = lim$ylim, xlab = "x1", ylab = "x2", main = "Data")
-  grid(col = "gray90", lty = 3)
-  draw_points(S, style)
-  legend("bottomright", legend = c("Train", "Val", "Test"), pch = 16,
-         col = style$cols, pt.cex = c(style$cex, style$cex, style$cex * 1.1), bty = "n")
+  op <- par(mfrow = c(1, 3), mar = c(3, 3, 2, 1))
+  titles <- c(true = "True", trtf = "TRTF", ttm_cross = "Cross-term")
   for (nm in panels) {
-    Z <- matrix(LD_list[[nm]], nrow = length(xseq), ncol = length(yseq))
-    plot(NA, xlim = lim$xlim, ylim = lim$ylim, xlab = "x1", ylab = "x2", main = nm)
+    Z <- matrix(LD_list[[nm]], nrow = grid_side, ncol = grid_side)
+    plot(NA, xlim = xlim, ylim = ylim, xlab = "x1", ylab = "x2",
+         main = titles[[nm]])
     grid(col = "gray90", lty = 3)
-    contour(xseq, yseq, Z, levels = lev_list[[nm]], add = TRUE, drawlabels = FALSE)
+    contour(xseq, yseq, Z, levels = lev_list[[nm]], add = TRUE,
+            drawlabels = FALSE)
     draw_points(S, style)
-    legend("bottomright", legend = c("Train", "Val", "Test"), pch = 16,
-           col = style$cols, pt.cex = c(style$cex, style$cex, style$cex * 1.1), bty = "n")
   }
   par(op)
-  invisible(list(levels = lev_ret, grid_points = nrow(G), all_finite = all_finite))
-}
-
-plot_halfmoon_models <- function(mods, S, grid_n = 200,
-                                 levels_policy = c("global_quantiles", "per_model"),
-                                 save_png = TRUE, show_plot = TRUE,
-                                 seed = NULL) {
-  levels_policy <- match.arg(levels_policy)
-  if (!is.null(seed)) {
-    set.seed(seed)
-  } else if (!is.null(S$meta$seed)) {
-    set.seed(S$meta$seed)
-  }
   if (save_png) {
-    dir.create("results", showWarnings = FALSE)
-    seed0 <- if (!is.null(S$meta$seed)) S$meta$seed else 0
-    f <- sprintf("results/halfmoon_panels_seed%03d.png", seed0)
-    png(f, width = 1200, height = 800)
-    .draw_panels(mods, S, grid_n, levels_policy)
+    dir.create("results/moon", showWarnings = FALSE, recursive = TRUE)
+    ts <- format(Sys.time(), "%Y%m%d_%H%M%S")
+    out_dir <- file.path("results/moon", ts)
+    dir.create(out_dir)
+    png_file <- file.path(out_dir, sprintf("panels_seed%03d.png", seed))
+    png(png_file, width = 900, height = 300)
+    op2 <- par(mfrow = c(1, 3), mar = c(3, 3, 2, 1))
+    for (nm in panels) {
+      Z <- matrix(LD_list[[nm]], nrow = grid_side, ncol = grid_side)
+      plot(NA, xlim = xlim, ylim = ylim, xlab = "x1", ylab = "x2",
+           main = titles[[nm]])
+      grid(col = "gray90", lty = 3)
+      contour(xseq, yseq, Z, levels = lev_list[[nm]], add = TRUE,
+              drawlabels = FALSE)
+      draw_points(S, style)
+    }
+    par(op2)
     dev.off()
-    message("Saved: ", f)
+    meta <- list(seed = seed, grid_side = grid_side, chunk = chunk,
+                 cores = cores, cache_keys = sapply(evals, function(e) e$meta$cache_key))
+    saveRDS(meta, file.path(out_dir, "meta.rds"))
+    message("Gespeichert: ", png_file)
   }
   if (show_plot && interactive()) {
-    .draw_panels(mods, S, grid_n, levels_policy)
+    invisible() # plot already drawn
   }
-  invisible(TRUE)
-}
-
-#' ggplot2 panels for half-moon models
-#'
-#' Creates a 2x3 panel figure comparing data and model densities using
-#' `ggplot2` with filled contours at global quantile levels.
-plot_halfmoon_models_gg <- function(mods, S, grid_n = 200,
-                                    levels_policy = c("global_quantiles"),
-                                    save_png = TRUE, show_plot = FALSE) {
-  stopifnot(requireNamespace("ggplot2", quietly = TRUE))
-  levels_policy <- match.arg(levels_policy)
-  lim <- compute_limits(S, pad = 0.05)
-  xseq <- seq(lim$xlim[1], lim$xlim[2], length.out = grid_n)
-  yseq <- seq(lim$ylim[1], lim$ylim[2], length.out = grid_n)
-  G <- expand.grid(x1 = xseq, x2 = yseq)
-  get_LDj_true <- function(mod_true) {
-    cbind(
-      .log_density_vec(G$x1, "norm", mod_true$theta[[1]]),
-      .log_density_vec(G$x2, "norm", mod_true$theta[[2]])
-    ) |> rowSums()
-  }
-  get_LDj <- function(name) {
-    if (name == "true") get_LDj_true(mods$true)
-    else as.numeric(predict(mods[[name]], as.matrix(G), "logdensity"))
-  }
-  panels <- c("true", "trtf", "ttm", "ttm_sep", "ttm_cross")
-  LD_list <- setNames(lapply(panels, get_LDj), panels)
-  probs <- c(0.9, 0.7, 0.5)
-  all_vals <- unlist(lapply(LD_list, function(z) clip01(z[is.finite(z)])))
-  lev <- stats::quantile(all_vals, probs)
-  message("Contour levels (global): ", paste(sprintf("%.3f", lev), collapse = ", "))
-  df_ld <- do.call(rbind, lapply(panels, function(p) {
-    data.frame(G, LD = LD_list[[p]], panel = p)
-  }))
-  panel_levels <- c("data", panels)
-  make_df <- function(X, y, split) {
-    data.frame(x1 = X[, 1], x2 = X[, 2], y = y, split = split)
-  }
-  df_pts <- do.call(rbind, lapply(panel_levels, function(pl) {
-    rbind(
-      cbind(make_df(S$X_tr, S$y_tr, "Train"), panel = pl),
-      cbind(make_df(S$X_val, S$y_val, "Val"), panel = pl),
-      cbind(make_df(S$X_te, S$y_te, "Test"), panel = pl)
-    )
-  }))
-  df_ld$panel <- factor(df_ld$panel, levels = panel_levels[-1])
-  df_pts$panel <- factor(df_pts$panel, levels = panel_levels)
-  p <- ggplot2::ggplot() +
-    ggplot2::stat_contour_filled(data = df_ld,
-      ggplot2::aes(x1, x2, z = LD, fill = after_stat(level)),
-      breaks = lev) +
-    ggplot2::geom_point(data = df_pts,
-      ggplot2::aes(x1, x2, color = factor(y), shape = split),
-      alpha = 0.6) +
-    ggplot2::scale_color_manual(values = c("1" = "blue", "2" = "red"), name = "Mond") +
-    ggplot2::scale_shape_manual(values = c(Train = 16, Val = 17, Test = 15), name = "Split") +
-    ggplot2::coord_fixed(xlim = lim$xlim, ylim = lim$ylim) +
-    ggplot2::facet_wrap(~panel, nrow = 2) +
-    ggplot2::theme_minimal() +
-    ggplot2::guides(
-      fill = ggplot2::guide_colourbar(title = "log-density"),
-      color = ggplot2::guide_legend(title = "Mond"),
-      shape = ggplot2::guide_legend(title = "Split")
-    )
-  if (save_png) {
-    dir.create("results", showWarnings = FALSE)
-    seed0 <- if (!is.null(S$meta$seed)) S$meta$seed else 0
-    f <- sprintf("results/halfmoon_panels_seed%03d.png", seed0)
-    ggplot2::ggsave(f, p, width = 12, height = 8, dpi = 100)
-    message("Saved: ", f)
-  }
-  if (show_plot && interactive()) {
-    print(p)
-  }
-  invisible(TRUE)
+  invisible(list(evals = evals, levels = lev_list,
+                 png = if (save_png) png_file else NULL))
 }
 

--- a/tests/testthat/test_eval_density_grid.R
+++ b/tests/testthat/test_eval_density_grid.R
@@ -1,0 +1,24 @@
+library(testthat)
+source('../../scripts/halfmoon_plot.R')
+
+dummy_model <- list(mu = c(0,0), sd = c(1,1))
+class(dummy_model) <- 'dummy_model'
+assign('predict.dummy_model', function(object, newdata, type = c('logdensity', 'logdensity_by_dim'), ...) {
+  type <- match.arg(type)
+  ld1 <- dnorm(newdata[,1], object$mu[1], object$sd[1], log=TRUE)
+  ld2 <- dnorm(newdata[,2], object$mu[2], object$sd[2], log=TRUE)
+  if (type == 'logdensity_by_dim') cbind(ld1, ld2) else ld1 + ld2
+}, envir = .GlobalEnv)
+
+test_that('eval_density_grid liefert korrekte Dimensionen und Cache', {
+  xlim <- c(-1,1); ylim <- c(-1,1); gs <- 5L
+  xseq <- seq(xlim[1], xlim[2], length.out = gs)
+  yseq <- seq(ylim[1], ylim[2], length.out = gs)
+  G <- as.matrix(expand.grid(xseq, yseq))
+  res1 <- eval_density_grid(dummy_model, G, xlim, ylim, gs, seed=1, chunk=10, cores=1)
+  expect_equal(dim(res1$LD), c(gs^2, 2))
+  expect_equal(length(res1$joint), gs^2)
+  expect_true(all(is.finite(res1$LD)))
+  res2 <- eval_density_grid(dummy_model, G, xlim, ylim, gs, seed=1, chunk=10, cores=1)
+  expect_identical(res1$joint, res2$joint)
+})


### PR DESCRIPTION
## Summary
- add CLI flags to `main_moon.R` to control grid size and caching
- implement `eval_density_grid` with chunked parallel prediction and caching
- plot half-moon densities using iso-mass contour levels for TRUE, TRTF and cross-term models
- document adaptive grid and caching policy
- add unit test for `eval_density_grid`

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'`
- `Rscript main_moon.R --grid_side=80 --no_cache` *(fails: Execution halted at 70% progress, likely due to heavy computation)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6565285c8328b2a08d0a68197cd6